### PR TITLE
Build proto with gradle and move to api directory. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ gradle-app.setting
 
 # Compiled GNURadio flowgraphs
 flowgraphs/*.py
+
+# Generated golang code
+*.pb.go

--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,0 +1,15 @@
+Starcoder - a server to read/write data from/to the stars, written in Go.
+Copyright (C) 2018 InfoStellar, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -14,9 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
-
 syntax = "proto3";
 
 package starcoder;

--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package starcoder;
 
+option go_package = "/api";
+
 // The GNURadio process manager service definition.
 service ProcessManager {
   // Create a process

--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,61 @@ buildscript {
 }
 
 apply plugin: 'org.curioswitch.gradle-curiostack-plugin'
+apply plugin: 'org.curioswitch.gradle-grpc-api-plugin'
 apply plugin: 'com.github.blindpirate.gogradle'
 
 golang {
     version = '1.10'
     packagePath = 'github.com/infostellarinc/starcoder'
+}
+
+protobuf {
+    generateProtoTasks {
+        all().each { task ->
+            task.plugins {
+                gofast {
+                    option 'plugins=grpc'
+                    option 'Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types'
+                    option 'Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types'
+                    // Output into root directory for gogradle
+                    outputSubDir = '../../../../..'
+                }
+            }
+        }
+    }
+    plugins {
+        gofast {
+            path = project.file('.gogradle/project_gopath/bin/protoc-gen-gofast')
+        }
+    }
+}
+
+sourceSets {
+    main {
+        proto {
+            srcDir 'api'
+        }
+    }
+}
+
+task getProtocGoPlugin(type: com.github.blindpirate.gogradle.Go) {
+    outputs.file project.file('.gogradle/project_gopath/bin/protoc-gen-gofast')
+    go 'get -u github.com/gogo/protobuf/protoc-gen-gofast'
+}
+
+task deleteGeneratedFiles(type: Delete) {
+    delete fileTree(project.projectDir) {
+        include '**/*.pb.go'
+        include '**/*.mock.go'
+        include '**/rice-box.go'
+    }
+    delete 'vendor'
+}
+tasks.clean.dependsOn deleteGeneratedFiles
+
+afterEvaluate {
+    tasks.generateProto.dependsOn getProtocGoPlugin
+    tasks.goBuild.dependsOn tasks.generateProto
 }
 
 gcloud {
@@ -55,3 +105,10 @@ task wrapper(type: Wrapper) {
     distributionType = 'ALL'
 }
 
+// protobuf-gradle-plugin always apply Java plugin, but we don't need it.
+tasks.compileJava.enabled = false
+tasks.compileTestJava.enabled = false
+
+license {
+    header file('.baseline/copyright/001_gpl.txt')
+}

--- a/build.gradle
+++ b/build.gradle
@@ -110,5 +110,8 @@ tasks.compileJava.enabled = false
 tasks.compileTestJava.enabled = false
 
 license {
-    header file('.baseline/copyright/001_gpl.txt')
+    header file('LICENSE.header')
+    mapping {
+        proto = 'SLASHSTAR_STYLE'
+    }
 }


### PR DESCRIPTION
We prefer to use Gradle for building things for smarter incremental compiling and a strong ability to define build dependencies. We also don't like checking in generated code, regardless of the golang recommendations.