### PR TITLE
Enqueue msg sink

### DIFF
--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -28,6 +28,9 @@ service ProcessManager {
 
   // End a process
   rpc EndFlowgraph (EndFlowgraphRequest) returns (EndFlowgraphResponse) {}
+
+  // Stream from enqueue message sink block
+  rpc StreamPmt (StreamPmtRequest) returns (stream StreamPmtResponse) {}
 }
 
 // Complex number
@@ -141,4 +144,19 @@ message EndFlowgraphResponse {
 
   // Error message
   string error = 2;
+}
+
+// The message containing a serialized PMT (GNURadio Polymorphic Message Type)
+message StreamPmtRequest {
+  // Flowgraph ID
+  string processId = 1;
+
+  // Block ID for specifying which enqueue_msg_sink block to stream
+  string blockId = 2;
+}
+
+// The message containing a serialized PMT (GNURadio Polymorphic Message Type)
+message StreamPmtResponse {
+  // Serialized arbitrary PMT message
+  bytes bytes = 1;
 }

--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -22,7 +22,7 @@ package starcoder;
 option go_package = "/api";
 
 // The GNURadio process manager service definition.
-service StarCoder {
+service Starcoder {
   // Runs a flowgraph and streams back
   rpc RunFlowgraph (stream RunFlowgraphRequest) returns (stream RunFlowgraphResponse) {}
 }

--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -23,14 +23,36 @@ option go_package = "/api";
 
 // The GNURadio process manager service definition.
 service ProcessManager {
-  // Create a process
-  rpc StartFlowgraph (StartFlowgraphRequest) returns (StartFlowgraphResponse) {}
+  // Runs a flowgraph and streams back
+  rpc RunFlowgraph (stream RunFlowgraphRequest) returns (stream RunFlowgraphResponse) {}
+}
 
-  // End a process
-  rpc EndFlowgraph (EndFlowgraphRequest) returns (EndFlowgraphResponse) {}
+message RunFlowgraphRequest {
+  // Filename of GNURadio script to run
+  string filename = 1;
 
-  // Stream from enqueue message sink block
-  rpc StreamPmt (StreamPmtRequest) returns (stream StreamPmtResponse) {}
+  // Key value pair representing a parameter to be passed to the script
+  message Parameter {
+    // Name of parameter
+    string key = 1;
+
+    // Value to assign the parameter
+    Value value = 2;
+  }
+
+  // Arbitrary command line parameters to be passed to the GNURadio script
+  repeated Parameter parameters = 2;
+
+  // Blocks to stream back in the response
+  repeated string block_id = 3;
+}
+
+message RunFlowgraphResponse {
+  // Block ID to which this response belongs
+  string block_id = 1;
+
+  // Serialized arbitrary PMT (GNURadio Polymorphic Message Type)
+  bytes payload = 2;
 }
 
 // Complex number
@@ -60,103 +82,4 @@ message Value {
     // Represents a complex number
     Complex complex_value = 5;
   }
-}
-
-// The request message containing parameters for starting a flowgraph
-message StartFlowgraphRequest {
-  // Filename of GNURadio script to run
-  string filename = 1;
-
-  // Key value pair representing a parameter to be passed to the script
-  message Parameter {
-    // Name of parameter
-    string key = 1;
-
-    // Value to assign the parameter
-    Value value = 2;
-  }
-
-  // Arbitrary command line parameters to be passed to the GNURadio script
-  repeated Parameter parameters = 2;
-}
-
-// The message response to a StartFlowgraphRequest
-message StartFlowgraphResponse {
-  // Unique Process ID of the flowgraph that was started
-  string processId = 1;
-
-  // Response status
-  enum Status {
-    // Successfully started flowgraph.
-    SUCCESS = 0;
-
-    // File access problem
-    FILE_ACCESS_ERROR = 1;
-
-    // Unsupported file type
-    UNSUPPORTED_FILE_TYPE = 2;
-
-    // .grc compile error
-    GRC_COMPILE_ERROR = 3;
-
-    // Python file run error
-    PYTHON_RUN_ERROR = 4;
-
-    // Unknown error starting flowgraph.
-    UNKNOWN_ERROR = 255;
-  }
-
-  // Response status
-  Status status = 2;
-
-  // Error message
-  string error = 3;
-}
-
-// The request message containing parameters for ending a flowgraph
-message EndFlowgraphRequest {
-  // Process ID of process to end
-  string processId = 1;
-}
-
-// The message response to an EndFlowgraphRequest
-message EndFlowgraphResponse {
-  // Response status
-  enum Status {
-    // Successfully ended flowgraph.
-    SUCCESS = 0;
-
-    // Invalid Process Id
-    INVALID_PROCESS_ID = 1;
-
-    // Flowgraph has exited
-    PROCESS_EXITED = 2;
-
-    // Python file run error
-    PYTHON_RUN_ERROR = 3;
-
-    // Unknown error ending flowgraph.
-    UNKNOWN_ERROR = 255;
-  }
-
-  // Response status
-  Status status = 1;
-
-  // Error message
-  string error = 2;
-}
-
-// The message containing a serialized PMT (GNURadio Polymorphic Message Type)
-message StreamPmtRequest {
-  // Flowgraph ID
-  string processId = 1;
-
-  // Block ID for specifying which enqueue_msg_sink block to stream
-  string blockId = 2;
-}
-
-// The message containing a serialized PMT (GNURadio Polymorphic Message Type)
-message StreamPmtResponse {
-  // Serialized arbitrary PMT message
-  bytes bytes = 1;
 }

--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -21,12 +21,6 @@ package starcoder;
 
 option go_package = "/api";
 
-// The GNURadio process manager service definition.
-service Starcoder {
-  // Runs a flowgraph and streams back
-  rpc RunFlowgraph (stream RunFlowgraphRequest) returns (stream RunFlowgraphResponse) {}
-}
-
 message RunFlowgraphRequest {
   // Filename of GNURadio script to run
   string filename = 1;
@@ -82,4 +76,10 @@ message Value {
     // Represents a complex number
     Complex complex_value = 5;
   }
+}
+
+// The GNURadio process manager service definition.
+service Starcoder {
+  // Runs a flowgraph and streams back
+  rpc RunFlowgraph (stream RunFlowgraphRequest) returns (stream RunFlowgraphResponse) {}
 }

--- a/api/starcoder.proto
+++ b/api/starcoder.proto
@@ -22,7 +22,7 @@ package starcoder;
 option go_package = "/api";
 
 // The GNURadio process manager service definition.
-service ProcessManager {
+service StarCoder {
   // Runs a flowgraph and streams back
   rpc RunFlowgraph (stream RunFlowgraphRequest) returns (stream RunFlowgraphResponse) {}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -110,7 +110,7 @@ var serveCmd = &cobra.Command{
 			}
 		}(s)
 
-		pb.RegisterProcessManagerServer(s, starcoder)
+		pb.RegisterStarCoderServer(s, starcoder)
 
 		// Register reflection service on gRPC server.
 		reflection.Register(s)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -110,7 +110,7 @@ var serveCmd = &cobra.Command{
 			}
 		}(s)
 
-		pb.RegisterStarCoderServer(s, starcoder)
+		pb.RegisterStarcoderServer(s, starcoder)
 
 		// Register reflection service on gRPC server.
 		reflection.Register(s)

--- a/gr-starcoder/grc/CMakeLists.txt
+++ b/gr-starcoder/grc/CMakeLists.txt
@@ -18,5 +18,6 @@
 # Boston, MA 02110-1301, USA.
 
 install(FILES
-    starcoder_ar2300_source.xml DESTINATION share/gnuradio/grc/blocks
+    starcoder_ar2300_source.xml
+    starcoder_enqueue_msg_sink.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/gr-starcoder/grc/starcoder_enqueue_msg_sink.xml
+++ b/gr-starcoder/grc/starcoder_enqueue_msg_sink.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<block>
+  <name>Enqueue Message Sink</name>
+  <key>starcoder_enqueue_msg_sink</key>
+  <category>[starcoder]</category>
+  <import>import starcoder</import>
+  <make>starcoder.enqueue_msg_sink()</make>
+  <sink>
+    <name>in</name>
+    <type>message</type>
+  </sink>
+</block>

--- a/gr-starcoder/python/CMakeLists.txt
+++ b/gr-starcoder/python/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 GR_PYTHON_INSTALL(
     FILES
     __init__.py
-    DESTINATION ${GR_PYTHON_DIR}/starcoder
+    enqueue_msg_sink.py DESTINATION ${GR_PYTHON_DIR}/starcoder
 )
 
 ########################################################################
@@ -42,3 +42,4 @@ include(GrTest)
 set(GR_TEST_TARGET_DEPS gnuradio-starcoder)
 set(GR_TEST_PYTHON_DIRS ${CMAKE_BINARY_DIR}/swig)
 GR_ADD_TEST(qa_ar2300_source ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_ar2300_source.py)
+GR_ADD_TEST(qa_enqueue_msg_sink ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_enqueue_msg_sink.py)

--- a/gr-starcoder/python/__init__.py
+++ b/gr-starcoder/python/__init__.py
@@ -30,4 +30,5 @@ except ImportError:
   pass
 
 # import any pure python here
+from enqueue_msg_sink import enqueue_msg_sink
 #

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2018 <+YOU OR YOUR COMPANY+>.
+# 
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+import numpy
+from gnuradio import gr
+import pmt
+from collections import deque
+
+class enqueue_msg_sink(gr.basic_block):
+    """
+    docstring for block enqueue_msg_sink
+    """
+    def __init__(self):
+        gr.basic_block.__init__(self,
+            name="enqueue_msg_sink",
+            in_sig=[],
+            out_sig=[])
+        self.q = deque()
+        self.message_port_register_in(pmt.intern("in"))
+        self.set_msg_handler(pmt.intern("in"), self.msg_handler)
+
+    def get_q(self):
+        return self.q
+
+    def msg_handler(self, pmt):
+        self.q.append(pmt)
+        print("Received pmt", pmt)

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -32,12 +32,16 @@ class enqueue_msg_sink(gr.basic_block):
             name="enqueue_msg_sink",
             in_sig=[],
             out_sig=[])
-        self.q = deque()
         self.message_port_register_in(pmt.intern("in"))
         self.set_msg_handler(pmt.intern("in"), self.msg_handler)
+        self.observers = []
 
-    def get_q(self):
-        return self.q
+    def observe(self):
+        q = deque()
+        self.observers.append(q)
+        return q
 
     def msg_handler(self, message):
-        self.q.append(bytearray(pmt.serialize_str(message)))
+        serialized_bytes = bytearray(pmt.serialize_str(message))
+        for q in self.observers:
+            q.append(serialized_bytes)

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # 
-# Copyright 2018 <+YOU OR YOUR COMPANY+>.
+# Copyright 2018 Infostellar.
 # 
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -24,7 +24,8 @@ import pmt
 
 class enqueue_msg_sink(gr.basic_block):
     """
-    docstring for block enqueue_msg_sink
+    This block can be "observed" by outside objects using its `observe` method.
+    Each PMT received by this block is given to all its registered observers.
     """
     def __init__(self):
         gr.basic_block.__init__(self,

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -19,7 +19,6 @@
 # Boston, MA 02110-1301, USA.
 # 
 
-import numpy
 from gnuradio import gr
 import pmt
 from collections import deque

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -39,6 +39,5 @@ class enqueue_msg_sink(gr.basic_block):
     def get_q(self):
         return self.q
 
-    def msg_handler(self, pmt):
-        self.q.append(pmt)
-        print("Received pmt", pmt)
+    def msg_handler(self, message):
+        self.q.append(bytearray(pmt.serialize_str(message)))

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -29,11 +29,11 @@ class enqueue_msg_sink(gr.basic_block):
     """
     def __init__(self):
         gr.basic_block.__init__(self,
-            name="enqueue_msg_sink",
+            name='enqueue_msg_sink',
             in_sig=[],
             out_sig=[])
-        self.message_port_register_in(pmt.intern("in"))
-        self.set_msg_handler(pmt.intern("in"), self.msg_handler)
+        self.message_port_register_in(pmt.intern('in'))
+        self.set_msg_handler(pmt.intern('in'), self.msg_handler)
         self.observers = []
 
     def observe(self):

--- a/gr-starcoder/python/enqueue_msg_sink.py
+++ b/gr-starcoder/python/enqueue_msg_sink.py
@@ -21,7 +21,6 @@
 
 from gnuradio import gr
 import pmt
-from collections import deque
 
 class enqueue_msg_sink(gr.basic_block):
     """
@@ -37,7 +36,7 @@ class enqueue_msg_sink(gr.basic_block):
         self.observers = []
 
     def observe(self):
-        q = deque()
+        q = []
         self.observers.append(q)
         return q
 

--- a/gr-starcoder/python/qa_ar2300_source.py
+++ b/gr-starcoder/python/qa_ar2300_source.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # 
-# Copyright 2018 <+YOU OR YOUR COMPANY+>.
+# Copyright 2018 Infostellar.
 # 
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gr-starcoder/python/qa_enqueue_msg_sink.py
+++ b/gr-starcoder/python/qa_enqueue_msg_sink.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # 
-# Copyright 2018 <+YOU OR YOUR COMPANY+>.
+# Copyright 2018 Infostellar.
 # 
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gr-starcoder/python/qa_enqueue_msg_sink.py
+++ b/gr-starcoder/python/qa_enqueue_msg_sink.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# 
+# Copyright 2018 <+YOU OR YOUR COMPANY+>.
+# 
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+# 
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this software; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+# 
+
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+from enqueue_msg_sink import enqueue_msg_sink
+
+class qa_enqueue_msg_sink (gr_unittest.TestCase):
+
+    def setUp (self):
+        self.tb = gr.top_block ()
+
+    def tearDown (self):
+        self.tb = None
+
+    def test_001_t (self):
+        # set up fg
+        self.tb.run ()
+        # check data
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_enqueue_msg_sink, "qa_enqueue_msg_sink.xml")

--- a/sampleclient/main.go
+++ b/sampleclient/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatalf("fail to dial: %v", err)
 	}
 	defer conn.Close()
-	client := pb.NewStarCoderClient(conn)
+	client := pb.NewStarcoderClient(conn)
 
 	stream, err := client.RunFlowgraph(context.Background())
 	waitc := make(chan struct{})

--- a/sampleclient/main.go
+++ b/sampleclient/main.go
@@ -1,0 +1,71 @@
+/*
+ * Starcoder - a server to read/write data from/to the stars, written in Go.
+ * Copyright (C) 2018 InfoStellar, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Sample client for testing starcoder
+package main
+
+import (
+	"context"
+	pb "github.com/infostellarinc/starcoder/api"
+	"google.golang.org/grpc"
+	"io"
+	"log"
+	"time"
+)
+
+func main() {
+	conn, err := grpc.Dial("127.0.0.1:8990", grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("fail to dial: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewProcessManagerClient(conn)
+
+	stream, err := client.RunFlowgraph(context.Background())
+	waitc := make(chan struct{})
+	go func() {
+		for {
+			r, err := stream.Recv()
+			if err == io.EOF {
+				close(waitc)
+				return
+			}
+			if err != nil {
+				log.Fatalf("%v", err)
+			}
+			log.Println(r.GetBlockId(), r.GetPayload())
+		}
+	}()
+	req := &pb.RunFlowgraphRequest{
+		Filename: "test.grc",
+		Parameters: []*pb.RunFlowgraphRequest_Parameter{
+			{
+				Key: "source_filepath",
+				Value: &pb.Value{
+					Val: &pb.Value_StringValue{StringValue: "/home/rei/sampleAR2300IQ/full.bin"},
+				},
+			},
+		},
+	}
+	if err := stream.Send(req); err != nil {
+		log.Fatalf("Failed to send: %v", err)
+	}
+	time.Sleep(10 * time.Second)
+	stream.CloseSend()
+	<-waitc
+}

--- a/sampleclient/main.go
+++ b/sampleclient/main.go
@@ -34,7 +34,7 @@ func main() {
 		log.Fatalf("fail to dial: %v", err)
 	}
 	defer conn.Close()
-	client := pb.NewProcessManagerClient(conn)
+	client := pb.NewStarCoderClient(conn)
 
 	stream, err := client.RunFlowgraph(context.Background())
 	waitc := make(chan struct{})

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -266,7 +266,9 @@ func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) er
 
 				iter := 0
 				key := python.PyString_FromString("")
+				defer key.DecRef()
 				val := python.PyString_FromString("")
+				defer val.DecRef()
 				for python.PyDict_Next(flowGraphDict, &iter, &key, &val) {
 					// Verify enqueue_msg_sink instance
 					isInstance := val.IsInstance(enqueueMessageSink)
@@ -335,12 +337,6 @@ func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) er
 						}()
 						pyLength := pmtQueue.CallMethod("__len__")
 						length := python.PyInt_AsLong(pyLength)
-
-						emptyTuple := python.PyTuple_New(0)
-						if emptyTuple == nil {
-							return nil, errors.New(getExceptionString())
-						}
-						defer emptyTuple.DecRef()
 
 						var bytes [][]byte
 

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -107,6 +107,177 @@ func (s *Starcoder) compileGrc(path string) (string, error) {
 	return inFilePythonPath, nil
 }
 
+func (s *Starcoder) startFlowGraph(inFilePythonPath string, request *pb.RunFlowgraphRequest) (*python.PyObject, map[string]*python.PyObject, error) {
+	runtime.LockOSThread()
+	python.PyEval_RestoreThread(s.threadState)
+	defer func() {
+		s.threadState = python.PyEval_SaveThread()
+		runtime.UnlockOSThread()
+	}()
+
+	// Append module directory to sys.path
+	log.Printf("Appending %v to sys.path", filepath.Dir(inFilePythonPath))
+	sysPath := python.PySys_GetObject("path")
+	if sysPath == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	moduleDir := python.PyString_FromString(filepath.Dir(inFilePythonPath))
+	if moduleDir == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer moduleDir.DecRef()
+	err := python.PyList_Append(sysPath, moduleDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Import module
+	moduleName := strings.TrimSuffix(filepath.Base(inFilePythonPath), filepath.Ext(filepath.Base(inFilePythonPath)))
+	log.Printf("Importing %v", moduleName)
+	module := python.PyImport_ImportModule(moduleName)
+	if module == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer module.DecRef()
+
+	// Find top_block subclass
+	// GRC compiled python scripts have the top block class name equal to the python filename.
+	flowGraphClassName := moduleName
+	flowgraphClass := module.GetAttrString(flowGraphClassName)
+	if flowgraphClass == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer flowgraphClass.DecRef()
+	gnuRadioModule := python.PyImport_ImportModule("gnuradio")
+	if gnuRadioModule == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer gnuRadioModule.DecRef()
+	grModule := gnuRadioModule.GetAttrString("gr")
+	if grModule == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer grModule.DecRef()
+	topBlock := grModule.GetAttrString("top_block")
+	if topBlock == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer topBlock.DecRef()
+
+	// Verify top_block subclass
+	isSubclass := flowgraphClass.IsSubclass(topBlock)
+	if isSubclass == 0 {
+		return nil, nil, errors.New(fmt.Sprintf(
+			"Top block class %v is not a "+
+				"subclass of gnuradio.gr.top_block", flowGraphClassName))
+
+	} else if isSubclass == -1 {
+		return nil, nil, errors.New(getExceptionString())
+	}
+
+	kwArgs := python.PyDict_New()
+	if kwArgs == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer kwArgs.DecRef()
+
+	for _, param := range request.GetParameters() {
+		err := func() error {
+			pyKey := python.PyString_FromString(param.GetKey())
+			if pyKey == nil {
+				return errors.New(getExceptionString())
+			}
+			defer pyKey.DecRef()
+			var convertedValue *python.PyObject
+			switch v := param.GetValue().GetVal().(type) {
+			case *pb.Value_StringValue:
+				convertedValue = python.PyString_FromString(v.StringValue)
+			case *pb.Value_IntegerValue:
+				convertedValue = python.PyInt_FromLong(int(v.IntegerValue))
+			case *pb.Value_LongValue:
+				convertedValue = python.PyLong_FromLongLong(v.LongValue)
+			case *pb.Value_FloatValue:
+				convertedValue = python.PyFloat_FromDouble(v.FloatValue)
+			case *pb.Value_ComplexValue:
+				convertedValue = python.PyComplex_FromDoubles(
+					v.ComplexValue.GetRealValue(),
+					v.ComplexValue.GetImaginaryValue())
+			default:
+				return errors.New("unsupported value type")
+			}
+			if convertedValue == nil {
+				return errors.New(getExceptionString())
+			}
+			defer convertedValue.DecRef()
+			err := python.PyDict_SetItem(kwArgs, pyKey, convertedValue)
+			if err != nil {
+				return errors.New(getExceptionString())
+			}
+			return nil
+		}()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	emptyTuple := python.PyTuple_New(0)
+	if emptyTuple == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer emptyTuple.DecRef()
+
+	flowGraphInstance := flowgraphClass.Call(emptyTuple, kwArgs)
+	if flowGraphInstance == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+
+	callReturn := flowGraphInstance.CallMethod("start")
+	if callReturn == nil {
+		return nil, nil, errors.New(getExceptionString())
+	}
+	defer callReturn.DecRef()
+
+	msgSinkBlocks := make(map[string]*python.PyObject)
+
+	// Look for any Enqueue Message Sink blocks
+	starcoderModule := python.PyImport_ImportModule("starcoder")
+	if starcoderModule == nil {
+		log.Println("gr-starcoder module not found. There are no Enqueue Message Sink blocks")
+	} else {
+		defer starcoderModule.DecRef()
+
+		enqueueMessageSink := starcoderModule.GetAttrString("enqueue_msg_sink")
+		if enqueueMessageSink == nil {
+			log.Println("gr-starcoder module does not contain enqueue_msg_sink")
+		} else {
+			defer enqueueMessageSink.DecRef()
+			flowGraphDict := flowGraphInstance.GetAttrString("__dict__")
+			if flowGraphDict == nil {
+				return nil, nil, errors.New(getExceptionString())
+			}
+			defer flowGraphDict.DecRef()
+
+			iter := 0
+			key := python.PyString_FromString("")
+			defer key.DecRef()
+			val := python.PyString_FromString("")
+			defer val.DecRef()
+			for python.PyDict_Next(flowGraphDict, &iter, &key, &val) {
+				// Verify enqueue_msg_sink instance
+				isInstance := val.IsInstance(enqueueMessageSink)
+				if isInstance == 1 {
+					k := python.PyString_AsString(key)
+					msgSinkBlocks[k] = val
+					fmt.Println("found enqueue_msg_sink block:", k)
+				} else if isInstance == -1 {
+					log.Println(getExceptionString())
+				}
+			}
+		}
+	}
+	return flowGraphInstance, msgSinkBlocks, nil
+}
+
 func (s *Starcoder) RunFlowgraph(stream pb.Starcoder_RunFlowgraphServer) error {
 	in, err := stream.Recv()
 	if err == io.EOF {
@@ -123,176 +294,7 @@ func (s *Starcoder) RunFlowgraph(stream pb.Starcoder_RunFlowgraphServer) error {
 		return err
 	}
 
-	flowGraphInstance, msgSinkBlocks, err := func() (*python.PyObject, map[string]*python.PyObject, error) {
-		runtime.LockOSThread()
-		python.PyEval_RestoreThread(s.threadState)
-		defer func() {
-			s.threadState = python.PyEval_SaveThread()
-			runtime.UnlockOSThread()
-		}()
-
-		// Append module directory to sys.path
-		log.Printf("Appending %v to sys.path", filepath.Dir(inFilePythonPath))
-		sysPath := python.PySys_GetObject("path")
-		if sysPath == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		moduleDir := python.PyString_FromString(filepath.Dir(inFilePythonPath))
-		if moduleDir == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer moduleDir.DecRef()
-		err = python.PyList_Append(sysPath, moduleDir)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Import module
-		moduleName := strings.TrimSuffix(filepath.Base(inFilePythonPath), filepath.Ext(filepath.Base(inFilePythonPath)))
-		log.Printf("Importing %v", moduleName)
-		module := python.PyImport_ImportModule(moduleName)
-		if module == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer module.DecRef()
-
-		// Find top_block subclass
-		// GRC compiled python scripts have the top block class name equal to the python filename.
-		flowGraphClassName := moduleName
-		flowgraphClass := module.GetAttrString(flowGraphClassName)
-		if flowgraphClass == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer flowgraphClass.DecRef()
-		gnuRadioModule := python.PyImport_ImportModule("gnuradio")
-		if gnuRadioModule == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer gnuRadioModule.DecRef()
-		grModule := gnuRadioModule.GetAttrString("gr")
-		if grModule == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer grModule.DecRef()
-		topBlock := grModule.GetAttrString("top_block")
-		if topBlock == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer topBlock.DecRef()
-
-		// Verify top_block subclass
-		isSubclass := flowgraphClass.IsSubclass(topBlock)
-		if isSubclass == 0 {
-			return nil, nil, errors.New(fmt.Sprintf(
-				"Top block class %v is not a "+
-					"subclass of gnuradio.gr.top_block", flowGraphClassName))
-
-		} else if isSubclass == -1 {
-			return nil, nil, errors.New(getExceptionString())
-		}
-
-		kwArgs := python.PyDict_New()
-		if kwArgs == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer kwArgs.DecRef()
-
-		for _, param := range in.GetParameters() {
-			err := func() error {
-				pyKey := python.PyString_FromString(param.GetKey())
-				if pyKey == nil {
-					return errors.New(getExceptionString())
-				}
-				defer pyKey.DecRef()
-				var convertedValue *python.PyObject
-				switch v := param.GetValue().GetVal().(type) {
-				case *pb.Value_StringValue:
-					convertedValue = python.PyString_FromString(v.StringValue)
-				case *pb.Value_IntegerValue:
-					convertedValue = python.PyInt_FromLong(int(v.IntegerValue))
-				case *pb.Value_LongValue:
-					convertedValue = python.PyLong_FromLongLong(v.LongValue)
-				case *pb.Value_FloatValue:
-					convertedValue = python.PyFloat_FromDouble(v.FloatValue)
-				case *pb.Value_ComplexValue:
-					convertedValue = python.PyComplex_FromDoubles(
-						v.ComplexValue.GetRealValue(),
-						v.ComplexValue.GetImaginaryValue())
-				default:
-					return errors.New("unsupported value type")
-				}
-				if convertedValue == nil {
-					return errors.New(getExceptionString())
-				}
-				defer convertedValue.DecRef()
-				err = python.PyDict_SetItem(kwArgs, pyKey, convertedValue)
-				if err != nil {
-					return errors.New(getExceptionString())
-				}
-				return nil
-			}()
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-
-		emptyTuple := python.PyTuple_New(0)
-		if emptyTuple == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer emptyTuple.DecRef()
-
-		flowGraphInstance := flowgraphClass.Call(emptyTuple, kwArgs)
-		if flowGraphInstance == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-
-		callReturn := flowGraphInstance.CallMethod("start")
-		if callReturn == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer callReturn.DecRef()
-
-		msgSinkBlocks := make(map[string]*python.PyObject)
-
-		// Look for any Enqueue Message Sink blocks
-		starcoderModule := python.PyImport_ImportModule("starcoder")
-		if starcoderModule == nil {
-			log.Println("gr-starcoder module not found. There are no Enqueue Message Sink blocks")
-		} else {
-			defer starcoderModule.DecRef()
-
-			enqueueMessageSink := starcoderModule.GetAttrString("enqueue_msg_sink")
-			if enqueueMessageSink == nil {
-				log.Println("gr-starcoder module does not contain enqueue_msg_sink")
-			} else {
-				defer enqueueMessageSink.DecRef()
-				flowGraphDict := flowGraphInstance.GetAttrString("__dict__")
-				if flowGraphDict == nil {
-					return nil, nil, errors.New(getExceptionString())
-				}
-				defer flowGraphDict.DecRef()
-
-				iter := 0
-				key := python.PyString_FromString("")
-				defer key.DecRef()
-				val := python.PyString_FromString("")
-				defer val.DecRef()
-				for python.PyDict_Next(flowGraphDict, &iter, &key, &val) {
-					// Verify enqueue_msg_sink instance
-					isInstance := val.IsInstance(enqueueMessageSink)
-					if isInstance == 1 {
-						k := python.PyString_AsString(key)
-						msgSinkBlocks[k] = val
-						fmt.Println("found enqueue_msg_sink block:", k)
-					} else if isInstance == -1 {
-						log.Println(getExceptionString())
-					}
-				}
-			}
-		}
-		return flowGraphInstance, msgSinkBlocks, nil
-	}()
+	flowGraphInstance, msgSinkBlocks, err := s.startFlowGraph(inFilePythonPath, in)
 	if err != nil {
 		return err
 	}

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -35,8 +35,6 @@ import (
 	"time"
 )
 
-import "C"
-
 type Starcoder struct {
 	flowgraphDir   string
 	temporaryDirs  []string

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -86,7 +86,7 @@ func NewStarcoderServer(flowgraphDir string) *Starcoder {
 	return s
 }
 
-func (s *Starcoder) CloseAllStreams() {
+func (s *Starcoder) closeAllStreams() {
 	respCh := make(chan bool)
 	s.closeAllStreamsChannel <- respCh
 	<-respCh
@@ -566,7 +566,7 @@ func (s *Starcoder) withPythonInterpreter(f func()) {
 }
 
 func (s *Starcoder) Close() error {
-	s.CloseAllStreams()
+	s.closeAllStreams()
 
 	runtime.LockOSThread()
 	python.PyEval_RestoreThread(s.threadState)

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -34,6 +34,8 @@ import (
 	"time"
 )
 
+import "C"
+
 type Starcoder struct {
 	flowgraphDir  string
 	temporaryDirs []string
@@ -53,7 +55,7 @@ func NewStarcoderServer(flowgraphDir string) *Starcoder {
 	}
 }
 
-func (s *Starcoder) RunFlowgraph(stream pb.StarCoder_RunFlowgraphServer) error {
+func (s *Starcoder) RunFlowgraph(stream pb.Starcoder_RunFlowgraphServer) error {
 	in, err := stream.Recv()
 	if err == io.EOF {
 		return nil

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -344,6 +344,7 @@ func (s *Starcoder) RunFlowgraph(stream pb.Starcoder_RunFlowgraphServer) error {
 		for {
 			select {
 			case <-closeChannel:
+				// TODO: Make this call unblock by getting rid of `wait`
 				err := s.stopFlowGraph(flowGraphInstance)
 				if err != nil {
 					return err

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -151,6 +151,7 @@ func newStreamHandler(sc *Starcoder, stream pb.Starcoder_RunFlowgraphServer, fgI
 					bytes, err := sh.starcoder.getBytesFromQueue(pmtQueue)
 					if err != nil {
 						sh.streamError = err
+						break
 					}
 					for _, b := range bytes {
 						if err := stream.Send(&pb.RunFlowgraphResponse{
@@ -158,6 +159,7 @@ func newStreamHandler(sc *Starcoder, stream pb.Starcoder_RunFlowgraphServer, fgI
 							Payload: b,
 						}); err != nil {
 							sh.streamError = err
+							break
 						}
 					}
 				}

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -313,6 +313,7 @@ func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) er
 				return
 			}
 			if err != nil {
+				closeChannel <- true
 				log.Printf("%v", err)
 				return
 			}

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -53,7 +53,7 @@ func NewStarcoderServer(flowgraphDir string) *Starcoder {
 	}
 }
 
-func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) error {
+func (s *Starcoder) RunFlowgraph(stream pb.StarCoder_RunFlowgraphServer) error {
 	in, err := stream.Recv()
 	if err == io.EOF {
 		return nil
@@ -136,12 +136,6 @@ func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) er
 		if err != nil {
 			return nil, nil, err
 		}
-
-		emptyTuple := python.PyTuple_New(0)
-		if emptyTuple == nil {
-			return nil, nil, errors.New(getExceptionString())
-		}
-		defer emptyTuple.DecRef()
 
 		// Import module
 		moduleName := strings.TrimSuffix(filepath.Base(inFilePythonPath), filepath.Ext(filepath.Base(inFilePythonPath)))
@@ -231,6 +225,12 @@ func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) er
 				return nil, nil, err
 			}
 		}
+
+		emptyTuple := python.PyTuple_New(0)
+		if emptyTuple == nil {
+			return nil, nil, errors.New(getExceptionString())
+		}
+		defer emptyTuple.DecRef()
 
 		flowGraphInstance := flowgraphClass.Call(emptyTuple, kwArgs)
 		if flowGraphInstance == nil {
@@ -350,7 +350,6 @@ func (s *Starcoder) RunFlowgraph(stream pb.ProcessManager_RunFlowgraphServer) er
 							if err != nil {
 								return nil, err
 							}
-							log.Println(k, pmtBytes)
 							bytes = append(bytes, pmtBytes)
 						}
 						return bytes, nil


### PR DESCRIPTION
#### gr-starcoder changes:
Adds a block called `enqueue_msg_sink`. Provides method to grab a queue which can then be polled for new entries, so you can do anything with them (sent through gRPC, in our case).

Written in Python for now for simplicity, but performance-wise, this isn't really a bottleneck for us since it is out of the path of GNURadio streaming blocks (it only handles async messages, not samples).

#### Starcoder changes:
Searches the flowgraph for `enqueue_msg_sink` blocks. User can then call `StreamPmt` for a particular block to get a stream of the messages from that block.