### PR TITLE
Add a task that automatically build gnuradio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
     }
     dependencies {
         classpath 'gradle.plugin.com.github.blindpirate:gogradle:0.8.0'
-        classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.115'
+        classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.127'
     }
 }
 
@@ -47,7 +47,6 @@ golang {
 }
 
 def gopath = System.env['GOPATH'] ?: project.file('.gogradle/project_gopath').toString()
-println gopath
 
 protobuf {
     generateProtoTasks {
@@ -100,7 +99,7 @@ gcloud {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.5.1'
+    gradleVersion = '4.6'
     distributionType = 'ALL'
 }
 
@@ -196,3 +195,47 @@ tasks.resolveBuildDependencies.enabled = false
 tasks.resolveTestDependencies.enabled = false
 
 tasks.build.dependsOn tasks.goBuild
+
+envs {
+    conda 'miniconda2-gnuradio', 'Miniconda2-4.4.10', [
+            'pybombs',
+            'cheetah',
+            'lxml',
+            'mako',
+            'requests',
+            condaPackage('autoconf'),
+            condaPackage('automake'),
+            condaPackage('boost'),
+            condaPackage('cmake'),
+            condaPackage('gcc_linux-64'),
+            condaPackage('gfortran_linux-64'),
+            condaPackage('gxx_linux-64'),
+            condaPackage('git'),
+            condaPackage('gsl'),
+            condaPackage('libtool'),
+            condaPackage('make'),
+            condaPackage('numpy'),
+            condaPackage('swig'),
+            condaPackage('wget'),
+    ]
+}
+
+ext.gnuradioRoot = gradle.gradleUserHomeDir.toPath().resolve('curiostack/python/bootstrap/miniconda2-gnuradio')
+
+def condaCommand(command) {
+    return """
+    . ${gnuradioRoot.resolve('etc/profile.d/conda.sh')} && \\
+    conda activate && \\
+    ${command}
+    """
+}
+
+task setupPrefix(type: Exec) {
+    dependsOn 'pythonSetup'
+    executable 'bash'
+    args '-c', condaCommand("""pybombs auto-config && \\
+        pybombs recipes add-defaults && \\
+        pybombs recipes add gr-starcoder ${project.file('gr-recipes')} && \\
+        pybombs -v prefix init ${gnuradioRoot} -a gnuradio -R gnuradio-nogui
+    """)
+}

--- a/gr-recipes/gnuradio-nogui.lwr
+++ b/gr-recipes/gnuradio-nogui.lwr
@@ -1,0 +1,106 @@
+#
+# Starcoder - a server to read/write data from/to the stars, written in Go.
+# Copyright (C) 2018 InfoStellar, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+inherit: prefix
+depends:
+- gnuradio
+config:
+  config:
+    # git cache causes recursive clone to fail for some reason. With only one prefix, there isn't much
+    # point in having it anyways.
+    git-cache: ''
+    # sudo shouldn't be required to setup
+    elevate_pre_args: ''
+    packagers:
+    - pkgconfig
+
+  packages:
+    gnuradio:
+      forcebuild: true
+      gitbranch: v3.7.11
+      # No gui dependencies
+      depends:
+      - boost
+      - fftw
+      - cppunit
+      - swig
+      - gsl
+      - uhd
+      - cheetah
+      - numpy
+      - lxml
+      - liblog4cpp
+      vars:
+        config_opt: "-DENABLE_DOXYGEN=OFF -DENABLE_GR_AUDIO=OFF -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=OFF -DENABLE_GR_UHD=ON -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=OFF"
+
+    liblog4cpp:
+      # Older versions don't compile on modern gcc.
+      source: wget+http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.3.tar.gz
+    uhd:
+      gitbranch: v3.11.0.0
+      vars:
+        config_opt: "-DENABLE_EXAMPLES=off"
+
+    # All these dependencies are installed through miniconda.
+    autoconf:
+      forceinstalled: true
+    automake:
+      forceinstalled: true
+    autotools-bootstrap:
+      forceinstalled: true
+    boost:
+      forceinstalled: true
+    build-essential:
+      forceinstalled: true
+    cheetah:
+      forceinstalled: true
+    cmake:
+      forceinstalled: true
+    doxygen:
+      forceinstalled: true
+    gcc:
+      forceinstalled: true
+    gsl:
+      forceinstalled: true
+    libtool:
+      forceinstalled: true
+    lxml:
+      forceinstalled: true
+    make:
+      forceinstalled: true
+    mako:
+      forceinstalled: true
+    numpy:
+      forceinstalled: true
+    python:
+      forceinstalled: true
+    python-requests:
+      forceinstalled: true
+    setuptools:
+      forceinstalled: true
+    swig:
+      forceinstalled: true
+    wget:
+      forceinstalled: true
+
+  categories:
+    baseline:
+      forcebuild: true
+    hardware:
+      forcebuild: true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,23 +1,4 @@
-#
-# Starcoder - a server to read/write data from/to the stars, written in Go.
-# Copyright (C) 2018 InfoStellar, Inc.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
-
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The only dependency is Java, all other native dependencies including compiler toolchain are from miniconda which is automatically set up.

I will later add support for building our blocks and the starcoder binary environment so there are no additional deps.