### PR TITLE
Cleanup

### DIFF
--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -603,11 +603,14 @@ func (s *Starcoder) stopFlowGraph(flowGraphInstance *python.PyObject) error {
 }
 
 func (s *Starcoder) withPythonInterpreter(f func()) {
+	// TODO: Why is this lock needed?
+	s.compileLock.Lock()
 	runtime.LockOSThread()
 	python.PyEval_RestoreThread(s.threadState)
 	f()
 	s.threadState = python.PyEval_SaveThread()
 	runtime.UnlockOSThread()
+	s.compileLock.Unlock()
 }
 
 func (s *Starcoder) Close() error {


### PR DESCRIPTION
Some cleanup changes:

- Cache compiled flow graphs so we don't need to compile them more than once.
- Let stream handler signal to Starcoder it needs to be closed via goroutine instead of starcoder polling each stream handler
- Adds a lock around `withPythonInterpreter` since starting two flow graphs at nearly the same time causes a panic. Not sure why. I checked the current master branch and this was already a problem so not introduced by the other changes in this PR.