### PR TITLE
Add support for building gr-starcoder with the builder's gnuradio pre…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,6 +243,8 @@ task setupPrefix(type: Exec) {
     """)
     // For some reason, cmake has trouble finding boost in certain situations.
     environment 'BOOST_ROOT', gnuradioRoot
+
+    environment 'PKG_CONFIG_PATH', "${gnuradioRoot}/lib/pkgconfig"
 }
 
 task installGrStarcoder(type: Exec) {
@@ -257,4 +259,6 @@ task installGrStarcoder(type: Exec) {
     doFirst {
         project.file('build/starcoder-cmake').mkdirs()
     }
+
+    environment 'PKG_CONFIG_PATH', "${gnuradioRoot}/lib/pkgconfig"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,7 @@ envs {
             condaPackage('gsl'),
             condaPackage('libtool'),
             condaPackage('make'),
+            condaPackage('matplotlib'),
             condaPackage('numpy'),
             condaPackage('swig'),
             condaPackage('wget'),

--- a/build.gradle
+++ b/build.gradle
@@ -231,11 +231,29 @@ def condaCommand(command) {
 }
 
 task setupPrefix(type: Exec) {
+    onlyIf { !project.file("${gnuradioRoot}/lib/libgnuradio-blocks.so").exists() }
+
     dependsOn 'pythonSetup'
     executable 'bash'
     args '-c', condaCommand("""pybombs auto-config && \\
-        pybombs recipes add-defaults && \\
-        pybombs recipes add gr-starcoder ${project.file('gr-recipes')} && \\
-        pybombs -v prefix init ${gnuradioRoot} -a gnuradio -R gnuradio-nogui
+        pybombs -y recipes add-defaults && \\
+        pybombs -y recipes add gr-starcoder ${project.file('gr-recipes')} && \\
+        pybombs -y -v prefix init ${gnuradioRoot} -a gnuradio -R gnuradio-nogui
     """)
+    // For some reason, cmake has trouble finding boost in certain situations.
+    environment 'BOOST_ROOT', gnuradioRoot
+}
+
+task installGrStarcoder(type: Exec) {
+    dependsOn setupPrefix
+    executable 'bash'
+    args '-c', condaCommand("""cmake ../../gr-starcoder -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=${gnuradioRoot} -Wno-dev && \\
+        make &&
+        make install
+    """)
+
+    workingDir project.file('build/starcoder-cmake')
+    doFirst {
+        project.file('build/starcoder-cmake').mkdirs()
+    }
 }

--- a/gr-recipes/gnuradio-nogui.lwr
+++ b/gr-recipes/gnuradio-nogui.lwr
@@ -33,7 +33,7 @@ config:
   packages:
     gnuradio:
       forcebuild: true
-      gitbranch: v3.7.11
+      gitbranch: v3.7.12.0
       # No gui dependencies
       depends:
       - boost
@@ -47,13 +47,13 @@ config:
       - lxml
       - liblog4cpp
       vars:
-        config_opt: "-DENABLE_DOXYGEN=OFF -DENABLE_GR_AUDIO=OFF -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=OFF -DENABLE_GR_UHD=ON -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=OFF"
+        config_opt: "-DENABLE_DOXYGEN=OFF -DENABLE_GR_AUDIO=OFF -DENABLE_GR_BLOCKS=ON -DENABLE_GR_DIGITAL=ON -DENABLE_GR_FEC=ON -DENABLE_GR_FFT=ON -DENABLE_GR_FILTER=ON -DENABLE_GR_QTGUI=OFF -DENABLE_GR_UHD=ON -DENABLE_GR_ZEROMQ=OFF -DENABLE_PYTHON=ON -DENABLE_VOLK=ON -DENABLE_GRC=OFF"
 
     liblog4cpp:
       # Older versions don't compile on modern gcc.
       source: wget+http://prdownloads.sourceforge.net/log4cpp/log4cpp-1.1.3.tar.gz
     uhd:
-      gitbranch: v3.11.0.0
+      gitbranch: v3.11.0.1
       vars:
         config_opt: "-DENABLE_EXAMPLES=off"
 

--- a/gr-starcoder/CMakeLists.txt
+++ b/gr-starcoder/CMakeLists.txt
@@ -133,6 +133,7 @@ endif(APPLE)
 # Find gnuradio build dependencies
 ########################################################################
 find_package(CppUnit)
+find_package(Log4cpp)
 find_package(Doxygen)
 
 # Search for GNU Radio and its components and versions. Add any
@@ -161,6 +162,7 @@ endif(DOXYGEN_FOUND)
 # Set up Python
 ########################################################################
 find_package(PythonLibs 2 REQUIRED)
+find_package(NumPy REQUIRED)
 
 ########################################################################
 # Setup the include and linker paths
@@ -174,6 +176,7 @@ include_directories(
     ${CPPUNIT_INCLUDE_DIRS}
     ${GNURADIO_ALL_INCLUDE_DIRS}
     ${PYTHON_INCLUDE_DIRS}
+    ${NumPy_INCLUDE_DIRS}
 )
 
 link_directories(

--- a/gr-starcoder/cmake/Modules/FindLog4cpp.cmake
+++ b/gr-starcoder/cmake/Modules/FindLog4cpp.cmake
@@ -1,0 +1,53 @@
+# - Find Log4cpp
+# Find the native LOG4CPP includes and library
+#
+#  LOG4CPP_INCLUDE_DIR - where to find LOG4CPP.h, etc.
+#  LOG4CPP_LIBRARIES   - List of libraries when using LOG4CPP.
+#  LOG4CPP_FOUND       - True if LOG4CPP found.
+
+
+if (LOG4CPP_INCLUDE_DIR)
+  # Already in cache, be silent
+  set(LOG4CPP_FIND_QUIETLY TRUE)
+endif ()
+
+find_path(LOG4CPP_INCLUDE_DIR log4cpp/Category.hh
+  /opt/local/include
+  /usr/local/include
+  /usr/include
+)
+
+set(LOG4CPP_NAMES log4cpp)
+find_library(LOG4CPP_LIBRARY
+  NAMES ${LOG4CPP_NAMES}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib
+)
+
+
+if (LOG4CPP_INCLUDE_DIR AND LOG4CPP_LIBRARY)
+  set(LOG4CPP_FOUND TRUE)
+  set(LOG4CPP_LIBRARIES ${LOG4CPP_LIBRARY} CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIRS ${LOG4CPP_INCLUDE_DIR} CACHE INTERNAL "" FORCE)
+else ()
+  set(LOG4CPP_FOUND FALSE CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_LIBRARY "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_LIBRARIES "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIR "" CACHE INTERNAL "" FORCE)
+  set(LOG4CPP_INCLUDE_DIRS "" CACHE INTERNAL "" FORCE)
+endif ()
+
+if (LOG4CPP_FOUND)
+  if (NOT LOG4CPP_FIND_QUIETLY)
+    message(STATUS "Found LOG4CPP: ${LOG4CPP_LIBRARIES}")
+  endif ()
+else ()
+  if (LOG4CPP_FIND_REQUIRED)
+    message(STATUS "Looked for LOG4CPP libraries named ${LOG4CPPS_NAMES}.")
+    message(FATAL_ERROR "Could NOT find LOG4CPP library")
+  endif ()
+endif ()
+
+mark_as_advanced(
+  LOG4CPP_LIBRARIES
+  LOG4CPP_INCLUDE_DIRS
+)

--- a/gr-starcoder/cmake/Modules/FindNumPy.cmake
+++ b/gr-starcoder/cmake/Modules/FindNumPy.cmake
@@ -1,0 +1,145 @@
+# Starcoder - a server to read/write data from/to the stars, written in Go.
+# Copyright (C) 2018 InfoStellar, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2014 Mike Sarahan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#.rst:
+#
+# Find the include directory for ``numpy/arrayobject.h`` as well as other NumPy tools like ``conv-template`` and
+# ``from-template``.
+#
+# This module sets the following variables:
+#
+# ``NumPy_FOUND``
+#   True if NumPy was found.
+# ``NumPy_INCLUDE_DIRS``
+#   The include directories needed to use NumpPy.
+# ``NumPy_VERSION``
+#   The version of NumPy found.
+# ``NumPy_CONV_TEMPLATE_EXECUTABLE``
+#   Path to conv-template executable.
+# ``NumPy_FROM_TEMPLATE_EXECUTABLE``
+#   Path to from-template executable.
+#
+# The module will also explicitly define one cache variable:
+#
+# ``NumPy_INCLUDE_DIR``
+#
+# .. note::
+#
+#     To support NumPy < v0.15.0 where ``from-template`` and ``conv-template`` are not declared as entry points,
+#     the module emulates the behavior of standalone executables by setting the corresponding variables with the
+#     path the the python interpreter and the path to the associated script. For example:
+#     ::
+#
+#         set(NumPy_CONV_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/conv_template.py CACHE STRING "Command executing conv-template program" FORCE)
+#
+#         set(NumPy_FROM_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/from_template.py CACHE STRING "Command executing from-template program" FORCE)
+#
+
+if(NOT NumPy_FOUND)
+  set(_find_extra_args)
+  if(NumPy_FIND_REQUIRED)
+    list(APPEND _find_extra_args REQUIRED)
+  endif()
+  if(NumPy_FIND_QUIET)
+    list(APPEND _find_extra_args QUIET)
+  endif()
+  find_package(PythonInterp ${_find_extra_args})
+  find_package(PythonLibs ${_find_extra_args})
+
+  find_program(NumPy_CONV_TEMPLATE_EXECUTABLE NAMES conv-template)
+  find_program(NumPy_FROM_TEMPLATE_EXECUTABLE NAMES from-template)
+
+  if(PYTHON_EXECUTABLE)
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+      -c "import numpy; print(numpy.get_include())"
+      OUTPUT_VARIABLE _numpy_include_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      )
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+      -c "import numpy; print(numpy.__version__)"
+      OUTPUT_VARIABLE NumPy_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      )
+
+    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+    if(NOT NumPy_CONV_TEMPLATE_EXECUTABLE)
+      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+        -c "from numpy.distutils import conv_template; print(conv_template.__file__)"
+        OUTPUT_VARIABLE _numpy_conv_template_file
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+      set(NumPy_CONV_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_conv_template_file}" CACHE STRING "Command executing conv-template program" FORCE)
+    endif()
+
+    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+    if(NOT NumPy_FROM_TEMPLATE_EXECUTABLE)
+      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+        -c "from numpy.distutils import from_template; print(from_template.__file__)"
+        OUTPUT_VARIABLE _numpy_from_template_file
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+      set(NumPy_FROM_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_from_template_file}" CACHE STRING "Command executing from-template program" FORCE)
+    endif()
+  endif()
+endif()
+
+find_path(NumPy_INCLUDE_DIR
+  numpy/arrayobject.h
+  PATHS "${_numpy_include_dir}" "${PYTHON_INCLUDE_DIR}"
+  PATH_SUFFIXES numpy/core/include
+  )
+
+set(NumPy_INCLUDE_DIRS ${NumPy_INCLUDE_DIR})
+
+# handle the QUIETLY and REQUIRED arguments and set NumPy_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NumPy
+                                  REQUIRED_VARS
+                                    NumPy_INCLUDE_DIR
+                                    NumPy_CONV_TEMPLATE_EXECUTABLE
+                                    NumPy_FROM_TEMPLATE_EXECUTABLE
+                                  VERSION_VAR NumPy_VERSION
+                                  )
+
+mark_as_advanced(NumPy_INCLUDE_DIR)

--- a/gr-starcoder/lib/CMakeLists.txt
+++ b/gr-starcoder/lib/CMakeLists.txt
@@ -59,29 +59,28 @@ GR_LIBRARY_FOO(gnuradio-starcoder RUNTIME_COMPONENT "starcoder_runtime" DEVEL_CO
 ########################################################################
 # Build and register unit test
 ########################################################################
-# TODO(anuraag): Figure out why this causes a link error undefined reference to `memcpy@GLIBC_2.14'
-# include(GrTest)
-#
-# include_directories( ${CPPUNIT_INCLUDE_DIRS} )
-#
-# list(APPEND test_starcoder_sources
-#     ${CMAKE_CURRENT_SOURCE_DIR}/test_starcoder.cc
-#     ${CMAKE_CURRENT_SOURCE_DIR}/qa_starcoder.cc
-# )
-#
-# add_executable(test-starcoder ${test_starcoder_sources})
-#
-# target_link_libraries(
-#   test-starcoder
-#   ${GNURADIO_RUNTIME_LIBRARIES}
-#   ${Boost_LIBRARIES}
-#   ${CPPUNIT_LIBRARIES}
-#   gnuradio-blocks
-#   gnuradio-starcoder
-#   ${PYTHON_LIBRARIES}
-# )
-#
-# GR_ADD_TEST(test_starcoder test-starcoder)
+include(GrTest)
+
+include_directories( ${CPPUNIT_INCLUDE_DIRS} )
+
+list(APPEND test_starcoder_sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_starcoder.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/qa_starcoder.cc
+)
+
+add_executable(test-starcoder ${test_starcoder_sources})
+
+target_link_libraries(
+  test-starcoder
+  ${GNURADIO_RUNTIME_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${CPPUNIT_LIBRARIES}
+  gnuradio-blocks
+  gnuradio-starcoder
+  ${PYTHON_LIBRARIES}
+)
+
+GR_ADD_TEST(test_starcoder test-starcoder)
 
 ########################################################################
 # Print summary

--- a/gr-starcoder/lib/CMakeLists.txt
+++ b/gr-starcoder/lib/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT starcoder_sources)
 endif(NOT starcoder_sources)
 
 add_library(gnuradio-starcoder SHARED ${starcoder_sources})
-target_link_libraries(gnuradio-starcoder ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES} usb-1.0)
+target_link_libraries(gnuradio-starcoder ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES} ${LOG4CPP_LIBRARY} usb-1.0)
 set_target_properties(gnuradio-starcoder PROPERTIES DEFINE_SYMBOL "gnuradio_starcoder_EXPORTS")
 
 if(APPLE)
@@ -59,28 +59,29 @@ GR_LIBRARY_FOO(gnuradio-starcoder RUNTIME_COMPONENT "starcoder_runtime" DEVEL_CO
 ########################################################################
 # Build and register unit test
 ########################################################################
-include(GrTest)
-
-include_directories( ${CPPUNIT_INCLUDE_DIRS} )
-
-list(APPEND test_starcoder_sources
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_starcoder.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/qa_starcoder.cc
-)
-
-add_executable(test-starcoder ${test_starcoder_sources})
-
-target_link_libraries(
-  test-starcoder
-  ${GNURADIO_RUNTIME_LIBRARIES}
-  ${Boost_LIBRARIES}
-  ${CPPUNIT_LIBRARIES}
-  gnuradio-blocks
-  gnuradio-starcoder
-  ${PYTHON_LIBRARIES}
-)
-
-GR_ADD_TEST(test_starcoder test-starcoder)
+# TODO(anuraag): Figure out why this causes a link error undefined reference to `memcpy@GLIBC_2.14'
+# include(GrTest)
+#
+# include_directories( ${CPPUNIT_INCLUDE_DIRS} )
+#
+# list(APPEND test_starcoder_sources
+#     ${CMAKE_CURRENT_SOURCE_DIR}/test_starcoder.cc
+#     ${CMAKE_CURRENT_SOURCE_DIR}/qa_starcoder.cc
+# )
+#
+# add_executable(test-starcoder ${test_starcoder_sources})
+#
+# target_link_libraries(
+#   test-starcoder
+#   ${GNURADIO_RUNTIME_LIBRARIES}
+#   ${Boost_LIBRARIES}
+#   ${CPPUNIT_LIBRARIES}
+#   gnuradio-blocks
+#   gnuradio-starcoder
+#   ${PYTHON_LIBRARIES}
+# )
+#
+# GR_ADD_TEST(test_starcoder test-starcoder)
 
 ########################################################################
 # Print summary

--- a/gr-starcoder/lib/init.c
+++ b/gr-starcoder/lib/init.c
@@ -17,9 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#define _GNU_SOURCE
 #include <errno.h>
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -382,24 +380,4 @@ void ar2300_set_fd(AR2300_HANDLE *ar2300, int fd) {
     return;
   }
   ar2300->outfd = fd;
-
-  // Get the current pipe size (this is just for debug info in the logs)
-  int currentSize = fcntl(fd, F_GETPIPE_SZ);
-  int maxPipeSize = 1048576;
-
-  // Determine max allowed pipe size and use it.
-  FILE *fp = fopen("/proc/sys/fs/pipe-max-size", "r");
-  if (fp == NULL) {
-    LOGGER(LOG_WARNING, "Couldn't open /proc/sys/fs/pipe-max-size");
-  } else {
-    char str[128];
-    if (fgets(str, 128, fp) != NULL) {
-      maxPipeSize = atoi(str);
-      LOGGER(LOG_INFO, "Max supported pipe size is %d\n", maxPipeSize);
-    }
-    fclose(fp);
-  }
-
-  int newSize = fcntl(fd, F_SETPIPE_SZ, maxPipeSize);
-  LOGGER(LOG_INFO, "Change pipe size from %d to %d\n", currentSize, newSize);
 }


### PR DESCRIPTION
…fix.

- Removed setting the pipe size since for some reason I couldn't get it to build, but we're currently working on removing it so think it's ok
- Not too sure why I had to add FindLog4cpp - did we run the gnuradio codegen without support for it? Was having problems linking against a gnuradio that includes log4cpp without it