### PR TITLE
Add dockerfile which prepares a running starcoder image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           keys:
           - v1-dependencies
 
-      - run: ./gradlew install
+      - run: ./gradlew --no-daemon install
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,16 +27,11 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "build.gradle" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v1-dependencies
 
-      - run: ./gradlew dependencies
+      - run: ./gradlew install
 
       - save_cache:
           paths:
             - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle" }}
-
-      # run tests!
-      - run: ./gradlew build
+          key: v1-dependencies

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+.baseline
+.circleci
+
+Dockerfile
+
+.dockerignore
+.gitignore
+README.md
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+*.iml
+*.ipr
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,12 +3,28 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/GeertJohan/go.incremental"
+  packages = ["."]
+  revision = "1172aab965109e2a70720a0f144b2a5dfeb92fa5"
+
+[[projects]]
+  branch = "master"
   name = "github.com/GeertJohan/go.rice"
   packages = [
     ".",
-    "embedded"
+    "embedded",
+    "rice"
   ]
   revision = "c02ca9a983da5807ddf7d796784928f5be4afd09"
+
+[[projects]]
+  name = "github.com/akavel/rsrc"
+  packages = [
+    "binutil",
+    "coff"
+  ]
+  revision = "a1fbfaf19b9ec69d75039b2a7cb4b048aecefddf"
+  version = "v2"
 
 [[projects]]
   branch = "master"
@@ -24,7 +40,35 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto"]
+  packages = [
+    "gogoproto",
+    "plugin/compare",
+    "plugin/defaultcheck",
+    "plugin/description",
+    "plugin/embedcheck",
+    "plugin/enumstringer",
+    "plugin/equal",
+    "plugin/face",
+    "plugin/gostring",
+    "plugin/marshalto",
+    "plugin/oneofcheck",
+    "plugin/populate",
+    "plugin/size",
+    "plugin/stringer",
+    "plugin/testgen",
+    "plugin/union",
+    "plugin/unmarshal",
+    "proto",
+    "protoc-gen-gofast",
+    "protoc-gen-gogo/descriptor",
+    "protoc-gen-gogo/generator",
+    "protoc-gen-gogo/grpc",
+    "protoc-gen-gogo/plugin",
+    "sortkeys",
+    "types",
+    "vanity",
+    "vanity/command"
+  ]
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
@@ -62,6 +106,12 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/jessevdk/go-flags"
+  packages = ["."]
+  revision = "c6ca198ec95c841fdb89fc0de7496fed11ab854e"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
@@ -229,6 +279,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "24ad54d12f4cb8280f1a2f0512d82a6c75a998b90db25f4038d3a25884331944"
+  inputs-digest = "1daf7cebdc41b1c663eba0e3e12bf0ffb180c498cba6a9cad5a7b152ff712d7d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,8 +27,11 @@
 required = [
   "github.com/golang/protobuf/proto",
   "github.com/gogo/protobuf/proto",
+  "github.com/gogo/protobuf/types",
+  "github.com/gogo/protobuf/protoc-gen-gofast",
   "google.golang.org/genproto",
   "github.com/GeertJohan/go.rice",
+  "github.com/GeertJohan/go.rice/rice",
   "github.com/spf13/cobra",
   "github.com/sbinet/go-python",
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@
  *
  */
 
+import de.undercouch.gradle.tasks.download.Download
+import org.apache.tools.ant.taskdefs.condition.Os
+
 buildscript {
     repositories {
         jcenter()
@@ -32,6 +35,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
+        classpath 'de.undercouch:gradle-download-task:3.3.0'
         classpath 'gradle.plugin.com.github.blindpirate:gogradle:0.8.0'
         classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.127'
     }
@@ -41,16 +45,15 @@ apply plugin: 'org.curioswitch.gradle-curiostack-plugin'
 apply plugin: 'org.curioswitch.gradle-grpc-api-plugin'
 apply plugin: 'com.github.blindpirate.gogradle'
 
+def GO_VERSION = '1.10'
+def DEP_VERSION = '0.4.1'
+
 golang {
-    version = '1.10'
+    version = GO_VERSION
     packagePath = 'github.com/infostellarinc/starcoder'
 }
 
 def gopath = System.env['GOPATH'] ?: project.file('.gogradle/project_gopath').toString()
-
-goBuild {
-    outputLocation = 'build/out/${PROJECT_NAME}${GOEXE}'
-}
 
 protobuf {
     generateProtoTasks {
@@ -79,11 +82,6 @@ sourceSets {
             srcDir 'api'
         }
     }
-}
-
-task getProtocGoPlugin(type: com.github.blindpirate.gogradle.Go) {
-    outputs.file project.file("${gopath}/bin/protoc-gen-gofast")
-    go 'get -u github.com/gogo/protobuf/protoc-gen-gofast'
 }
 
 task deleteGeneratedFiles(type: Delete) {
@@ -118,63 +116,131 @@ license {
     }
 }
 
+def arch = 'linux-amd64'
+if (Os.isFamily(Os.FAMILY_MAC)) {
+    arch = 'darwin-amd64'
+} else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    arch = 'windows-amd64'
+}
 
-task depGet(type: com.github.blindpirate.gogradle.Go) {
-    outputs.file project.file("${gopath}/bin/dep")
-    go 'get -u github.com/golang/dep/cmd/dep'
+def bindepsDir = project.file("${gradle.gradleUserHomeDir}/go/bindeps")
+def cachedDep = project.file("${bindepsDir}/dep/v${DEP_VERSION}-${arch}/dep")
+def dep = "${gopath}/bin/dep"
+def depcache = new File(gradle.gradleUserHomeDir, 'go/dep-cache').toString()
+
+ext.gnuradioRoot = gradle.gradleUserHomeDir.toPath().resolve('curiostack/python/bootstrap/miniconda2-gnuradio')
+
+def condaCommand(command) {
+    return """
+    . ${gnuradioRoot.resolve('etc/profile.d/conda.sh')} && \\
+    conda activate > /dev/null && \\
+    ${command}
+    """
+}
+
+goBuild {
+    run "bash -c '${condaCommand('$GOROOT/bin/go build -o build/out/starcoder github.com/infostellarinc/starcoder')}'"
+
+    environment 'PKG_CONFIG_PATH', "${gnuradioRoot}/lib/pkgconfig"
+}
+
+task depDownload(type: Download) {
+    src "https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-${arch}"
+    dest cachedDep
+
+    onlyIf { !cachedDep.exists() }
+
     doLast {
-        // Remove dep source code since it contains invalid symlinks that break gradle.
-        project.delete project.file("${gopath}/src/github.com/golang/dep")
+        cachedDep.executable = true
     }
 }
 
-task getRice(type: com.github.blindpirate.gogradle.Go) {
-    go 'get -u github.com/GeertJohan/go.rice/...'
+task depCopy(type: Copy) {
+    dependsOn depDownload
+
+    from cachedDep
+    into "${gopath}/bin"
+
+    inputs.file cachedDep
+    outputs.file dep
 }
 
+def goExecutable = tasks.goBuild.buildManager.goBinaryManager.getBinaryPath()
+
+task installProtocGoPlugin(type: Exec) {
+    dependsOn 'depEnsure'
+
+    inputs.file 'Gopkg.lock'
+    outputs.file project.file("${gopath}/bin/protoc-gen-gofast")
+
+    executable goExecutable
+    args 'install', '.'
+    workingDir project.file("${gopath}/src/github.com/gogo/protobuf/protoc-gen-gofast")
+    environment 'GOPATH', gopath
+}
+tasks.goVendor.dependsOn installProtocGoPlugin
+
+task installRice(type: Exec) {
+    dependsOn 'depEnsure'
+
+    inputs.file 'Gopkg.lock'
+    outputs.file project.file("${gopath}/bin/rice")
+
+    executable goExecutable
+    args 'install', '.'
+    workingDir project.file("${gopath}/src/github.com/GeertJohan/go.rice/rice")
+    environment 'GOPATH', gopath
+}
+tasks.goVendor.dependsOn installRice
+
 task useRice(type:Exec) {
-    dependsOn getRice
+    dependsOn installRice
     inputs.dir 'flowgraphs'
     outputs.file 'cmd/rice-box.go'
 
     workingDir project.file('cmd').toString()
-    commandLine project.file('.gogradle/project_gopath/bin/rice').toString(), 'embed-go'
+    commandLine project.file("${gopath}/bin/rice").toString(), 'embed-go'
 }
 
 tasks.goBuild.dependsOn useRice
 
-def buildManager = tasks.goBuild.buildManager
-
 afterEvaluate {
     task depEnsure(type: Exec) {
-        dependsOn depGet
+        dependsOn depCopy, 'goPrepare'
 
         inputs.file 'Gopkg.toml'
         inputs.file 'Gopkg.lock'
         outputs.dir 'vendor'
 
         // TODO(anuraaga): Figure out why just setting workingDir doesn't work
-        commandLine 'sh', '-c', "cd ${gopath}/src/github.com/infostellarinc/starcoder && " +
-                "${project.file(gopath)}/bin/dep ensure -vendor-only"
+        commandLine 'bash', '-c', condaCommand("cd ${gopath}/src/github.com/infostellarinc/starcoder && " +
+                "${project.file(gopath)}/bin/dep ensure -vendor-only")
         environment = [
-                'DEPCACHEDIR': new File(gradle.gradleUserHomeDir, 'go/dep-cache').toString(),
+                'DEPCACHEDIR': depcache,
                 'GOPATH'     : gopath,
                 'PATH': System.env['PATH']
         ]
         // workingDir "${gopath}/src/github.com/infostellarinc/starcoder"
+
+        doLast {
+            copy {
+                from 'vendor/github.com'
+                into "${gopath}/src/github.com"
+            }
+        }
     }
 
     task depUpdate(type: Exec) {
-        dependsOn depGet
+        dependsOn depCopy
 
         inputs.file 'Gopkg.toml'
         outputs.file 'Gopkg.lock'
 
         // TODO(anuraaga): Figure out why just setting workingDir doesn't work
-        commandLine 'sh', '-c', "cd ${gopath}/src/github.com/infostellarinc/starcoder && " +
-                "${project.file(gopath)}/bin/dep ensure -no-vendor"
+        commandLine 'sh', '-c', condaCommand("cd ${gopath}/src/github.com/infostellarinc/starcoder && " +
+                "${project.file(gopath)}/bin/dep ensure -no-vendor")
         environment = [
-                'DEPCACHEDIR': new File(gradle.gradleUserHomeDir, 'go/dep-cache').toString(),
+                'DEPCACHEDIR': depcache,
                 'GOPATH'     : gopath,
                 'PATH': System.env['PATH']
         ]
@@ -182,9 +248,8 @@ afterEvaluate {
     }
 
     tasks.goVendor.dependsOn depEnsure
-    tasks.depEnsure.dependsOn tasks.generateProto
-    tasks.generateProto.dependsOn getProtocGoPlugin
-    tasks.goBuild.dependsOn tasks.generateProto
+    tasks.generateProto.dependsOn installProtocGoPlugin
+    tasks.goVendor.dependsOn tasks.generateProto
 
     tasks.withType(com.github.blindpirate.gogradle.Go) {
         if (it.name.startsWith('build')) {
@@ -202,12 +267,6 @@ tasks.build.dependsOn tasks.goBuild
 
 envs {
     conda 'miniconda2-gnuradio', 'Miniconda2-4.4.10', [
-            'pybombs',
-            'cheetah',
-            'lxml',
-            'mako',
-            'matplotlib',
-            'requests',
             condaPackage('autoconf'),
             condaPackage('automake'),
             condaPackage('boost'),
@@ -220,25 +279,27 @@ envs {
             condaPackage('libtool'),
             condaPackage('make'),
             condaPackage('numpy'),
+            condaPackage('pkg-config'),
+            condaPackage('subprocess32'),
             condaPackage('swig'),
             condaPackage('wget'),
     ]
 }
 
-ext.gnuradioRoot = gradle.gradleUserHomeDir.toPath().resolve('curiostack/python/bootstrap/miniconda2-gnuradio')
+// We install pip packages after a first conda bootstrap so its build tools are available to compile
+// native extensions.
+task installPipPackages(type: Exec) {
+    dependsOn 'pythonSetup'
 
-def condaCommand(command) {
-    return """
-    . ${gnuradioRoot.resolve('etc/profile.d/conda.sh')} && \\
-    conda activate && \\
-    ${command}
-    """
+    executable 'bash'
+    // Python setuptools uses LDSHARED variable and ignores CC when linking.
+    args '-c', condaCommand('LDSHARED=$CC pip install cheetah lxml mako matplotlib pybombs requests')
 }
 
 task setupPrefix(type: Exec) {
     onlyIf { !project.file("${gnuradioRoot}/lib/libgnuradio-blocks.so").exists() }
 
-    dependsOn 'pythonSetup'
+    dependsOn 'installPipPackages'
     executable 'bash'
     args '-c', condaCommand("""pybombs auto-config && \\
         pybombs -y recipes add-defaults && \\

--- a/gr-recipes/gnuradio-nogui.lwr
+++ b/gr-recipes/gnuradio-nogui.lwr
@@ -55,7 +55,7 @@ config:
     uhd:
       gitbranch: v3.11.0.1
       vars:
-        config_opt: "-DENABLE_EXAMPLES=off"
+        config_opt: "-DENABLE_EXAMPLES=off -DENABLE_OCTOCLOCK=off"
 
     # All these dependencies are installed through miniconda.
     autoconf:

--- a/gr-recipes/gnuradio-nogui.lwr
+++ b/gr-recipes/gnuradio-nogui.lwr
@@ -22,6 +22,7 @@ depends:
 - gnuradio
 config:
   config:
+    makewidth: 2
     # git cache causes recursive clone to fail for some reason. With only one prefix, there isn't much
     # point in having it anyways.
     git-cache: ''

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -8,4 +8,7 @@ FROM debian:9-slim
 
 COPY --from=0 /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio
 
-CMD [ "bash", "-c", ". /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/etc/profile.d/conda.sh && conda activate > /dev/null && /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/bin/starcoder" ]
+ADD ./tools/builder/run.sh /usr/bin/run-starcoder
+
+ENTRYPOINT [ "run-starcoder" ]
+CMD [ "serve" ]

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:9-slim
+
+ADD . /workspace
+
+RUN cd /workspace && ./gradlew install
+
+FROM debian:9-slim
+
+COPY --from=0 /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio
+
+CMD [ "bash", "-c", ". /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/etc/profile.d/conda.sh && conda activate > /dev/null && /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/bin/starcoder" ]

--- a/tools/builder/run.sh
+++ b/tools/builder/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/etc/profile.d/conda.sh
+conda activate > /dev/null
+/root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/bin/starcoder $@


### PR DESCRIPTION
The Dockerfile runs the build, including `gnuradio` prefix setup, and copies the prefix into the image. The default command of the image is starcoder.

- Also migrated usages of `go get` to more efficient manual download / `dep ensure`
- Disabled octoclock in `uhd` build for now - I feel like i have previously been able to build with it, but for some reason couldn't, and I feel like there is an obvious bug in their `CMakeLists.txt` so will debug it. Anyways, we don't use octoclock