### PR TITLE
Send back waterfall plot on a string_queue

### DIFF
--- a/cqueue/c_queue.go
+++ b/cqueue/c_queue.go
@@ -45,10 +45,10 @@ func (q *CStringQueue) BlockingPop() string {
 	return q.queue.Blocking_pop()
 }
 
-func (q *CStringQueue) Wake() {
-	q.queue.Wake()
+func (q *CStringQueue) Close() {
+	q.queue.Close()
 }
 
-func (q *CStringQueue) Close() {
+func (q *CStringQueue) Delete() {
 	DeleteString_queue(q.queue)
 }

--- a/cqueue/string_queue.cc
+++ b/cqueue/string_queue.cc
@@ -22,7 +22,9 @@
 string_queue::string_queue(int buffer_size) : queue_(buffer_size) {}
 
 void string_queue::push(const std::string &item) {
+  std::unique_lock<std::mutex> lock(mutex_);
   bool pushed = queue_.push(item);
+  lock.unlock();
   if (pushed) {
     condition_var_.notify_one();
   }

--- a/cqueue/string_queue.cc
+++ b/cqueue/string_queue.cc
@@ -39,8 +39,7 @@ std::string string_queue::pop() {
 std::string string_queue::blocking_pop() {
   std::string a;
   std::unique_lock<std::mutex> lock(mutex_);
-  while (queue_.empty() && !closed_)
-    condition_var_.wait(lock);
+  condition_var_.wait(lock, [this]{return (!queue_.empty() || closed_);});
   queue_.pop(a);
   return a;
 }

--- a/cqueue/string_queue.cc
+++ b/cqueue/string_queue.cc
@@ -45,7 +45,7 @@ std::string string_queue::blocking_pop() {
   return a;
 }
 
-void string_queue::wake() {
+void string_queue::close() {
   std::unique_lock<std::mutex> lock(mutex_);
   closed_ = true;
   lock.unlock();

--- a/cqueue/string_queue.h
+++ b/cqueue/string_queue.h
@@ -25,7 +25,10 @@
 This class is a threadsafe single-producer single-consumer queue
 that provides both a non-blocking and blocking pop.
 Although the blocking_pop does not come with a timeout, external
-code can unblock it via the wake() method.
+code can unblock it via the wake() method. Note that after calling
+the wake() method, blocking_pop() will no longer block, and it is
+suggested to use the non-blocking pop() method to avoid mutex locking
+overhead.
 */
 class string_queue {
   public:
@@ -42,5 +45,6 @@ class string_queue {
     boost::lockfree::spsc_queue<std::string> queue_;
     std::condition_variable condition_var_;
     std::mutex mutex_;
+    bool closed_;
 };
 #endif /*STRING_QUEUE_H*/

--- a/cqueue/string_queue.h
+++ b/cqueue/string_queue.h
@@ -45,6 +45,6 @@ class string_queue {
     boost::lockfree::spsc_queue<std::string> queue_;
     std::condition_variable condition_var_;
     std::mutex mutex_;
-    volatile bool closed_;
+    bool closed_;
 };
 #endif /*STRING_QUEUE_H*/

--- a/cqueue/string_queue.h
+++ b/cqueue/string_queue.h
@@ -25,8 +25,8 @@
 This class is a threadsafe single-producer single-consumer queue
 that provides both a non-blocking and blocking pop.
 Although the blocking_pop does not come with a timeout, external
-code can unblock it via the wake() method. Note that after calling
-the wake() method, blocking_pop() will no longer block, and it is
+code can unblock it via the close() method. Note that after calling
+the close() method, blocking_pop() will no longer block, and it is
 suggested to use the non-blocking pop() method to avoid mutex locking
 overhead.
 */
@@ -40,11 +40,11 @@ class string_queue {
     std::string pop();
     std::string blocking_pop();
     unsigned long get_ptr() const;
-    void wake();
+    void close();
   private:
     boost::lockfree::spsc_queue<std::string> queue_;
     std::condition_variable condition_var_;
     std::mutex mutex_;
-    bool closed_;
+    volatile bool closed_;
 };
 #endif /*STRING_QUEUE_H*/

--- a/flowgraphs/test.grc
+++ b/flowgraphs/test.grc
@@ -533,6 +533,37 @@
     </param>
   </block>
   <block>
+    <key>starcoder_enqueue_message_sink</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(752, 408)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>partial_iq_sink</value>
+    </param>
+  </block>
+  <block>
     <key>starcoder_complex_to_msg_c</key>
     <param>
       <key>alias</key>
@@ -635,37 +666,6 @@
     <param>
       <key>id</key>
       <value>starcoder_enqueue_message_sink_0_0</value>
-    </param>
-  </block>
-  <block>
-    <key>starcoder_enqueue_message_sink</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(752, 408)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>starcoder_enqueue_message_sink_0_1</value>
     </param>
   </block>
   <block>
@@ -820,7 +820,7 @@
   </connection>
   <connection>
     <source_block_id>starcoder_complex_to_msg_c_0</source_block_id>
-    <sink_block_id>starcoder_enqueue_message_sink_0_1</sink_block_id>
+    <sink_block_id>partial_iq_sink</sink_block_id>
     <source_key>out</source_key>
     <sink_key>in</sink_key>
   </connection>

--- a/gr-starcoder/include/starcoder/enqueue_message_sink.h
+++ b/gr-starcoder/include/starcoder/enqueue_message_sink.h
@@ -42,7 +42,7 @@ namespace gr {
       typedef boost::shared_ptr<enqueue_message_sink> sptr;
 
       static sptr make();
-      virtual void register_queue_pointer(uint64_t ptr) = 0;
+      virtual void register_starcoder_queue(uint64_t ptr) = 0;
     };
 
   } // namespace starcoder

--- a/gr-starcoder/include/starcoder/waterfall_plotter.h
+++ b/gr-starcoder/include/starcoder/waterfall_plotter.h
@@ -56,17 +56,10 @@ namespace gr {
      public:
       typedef boost::shared_ptr<waterfall_plotter> sptr;
 
-      /*!
-       * \brief Return a shared_ptr to a new instance of starcoder::waterfall_plotter.
-       *
-       * To avoid accidental use of raw pointers, starcoder::waterfall_plotter's
-       * constructor is in a private implementation
-       * class. starcoder::waterfall_plotter::make is the public interface for
-       * creating new instances.
-       */
       static sptr
       make(double samp_rate, double center_freq,
            int rps, size_t fft_size, char* filename);
+      virtual void register_queue_pointer(uint64_t ptr) = 0;
     };
 
   } // namespace starcoder

--- a/gr-starcoder/include/starcoder/waterfall_plotter.h
+++ b/gr-starcoder/include/starcoder/waterfall_plotter.h
@@ -59,7 +59,7 @@ namespace gr {
       static sptr
       make(double samp_rate, double center_freq,
            int rps, size_t fft_size, char* filename);
-      virtual void register_queue_pointer(uint64_t ptr) = 0;
+      virtual void register_starcoder_queue(uint64_t ptr) = 0;
     };
 
   } // namespace starcoder

--- a/gr-starcoder/lib/enqueue_message_sink_impl.cc
+++ b/gr-starcoder/lib/enqueue_message_sink_impl.cc
@@ -69,7 +69,7 @@ namespace gr {
       return noutput_items;
     }
 
-    void enqueue_message_sink_impl::register_queue_pointer(uint64_t ptr) {
+    void enqueue_message_sink_impl::register_starcoder_queue(uint64_t ptr) {
       string_queue_ = reinterpret_cast<string_queue *>(ptr);
     }
 

--- a/gr-starcoder/lib/enqueue_message_sink_impl.h
+++ b/gr-starcoder/lib/enqueue_message_sink_impl.h
@@ -46,7 +46,7 @@ namespace gr {
 
       void handler(pmt::pmt_t msg);
 
-      void register_queue_pointer(uint64_t ptr);
+      void register_starcoder_queue(uint64_t ptr);
     };
 
   } // namespace starcoder

--- a/gr-starcoder/lib/qa_enqueue_message_sink.cc
+++ b/gr-starcoder/lib/qa_enqueue_message_sink.cc
@@ -71,7 +71,7 @@ namespace gr {
       gr::starcoder::enqueue_message_sink::sptr op = gr::starcoder::enqueue_message_sink::make();
       string_queue q(10);
 
-      op->register_queue_pointer(q.get_ptr());
+      op->register_starcoder_queue(q.get_ptr());
 
       gr::basic_block_sptr bb = op->to_basic_block();
       bb->_post(pmt::mp("in"), pmt::make_u8vector(10, 97)); // 97 is ascii for 'a'

--- a/gr-starcoder/lib/waterfall_plotter_impl.cc
+++ b/gr-starcoder/lib/waterfall_plotter_impl.cc
@@ -58,7 +58,8 @@ namespace gr {
         center_freq_(center_freq),
         rps_(rps),
         fft_size_(fft_size),
-        filename_(filename)
+        filename_(filename),
+        string_queue_(NULL)
     {}
 
     /*
@@ -171,12 +172,14 @@ namespace gr {
       if (result == NULL)
         goto error;
 
-      Py_ssize_t image_size;
-      image_size = PyString_Size(result);
-      char *image_buffer;
-      image_buffer = PyString_AsString(result);
-      if (image_buffer == NULL)
-        goto error;
+      if (string_queue_ != NULL) {
+        Py_ssize_t image_size = PyString_Size(result);
+        char *image_buffer = PyString_AsString(result);
+        if (image_buffer == NULL)
+          goto error;
+        const std::string image_binary(image_buffer, image_size);
+        string_queue_->push(image_binary);
+      }
 
 error:
       /* Cleanup code, shared by success and failure path */
@@ -198,6 +201,10 @@ error:
       PyGILState_Release(gstate);
       delete[] numpy_array_buffer;
       return true;
+    }
+
+    void waterfall_plotter_impl::register_queue_pointer(uint64_t ptr) {
+      string_queue_ = reinterpret_cast<string_queue *>(ptr);
     }
 
   } /* namespace starcoder */

--- a/gr-starcoder/lib/waterfall_plotter_impl.cc
+++ b/gr-starcoder/lib/waterfall_plotter_impl.cc
@@ -203,7 +203,7 @@ error:
       return true;
     }
 
-    void waterfall_plotter_impl::register_queue_pointer(uint64_t ptr) {
+    void waterfall_plotter_impl::register_starcoder_queue(uint64_t ptr) {
       string_queue_ = reinterpret_cast<string_queue *>(ptr);
     }
 

--- a/gr-starcoder/lib/waterfall_plotter_impl.h
+++ b/gr-starcoder/lib/waterfall_plotter_impl.h
@@ -57,7 +57,7 @@ namespace gr {
 
       virtual bool stop();
 
-      void register_queue_pointer(uint64_t ptr);
+      void register_starcoder_queue(uint64_t ptr);
     };
 
   } // namespace starcoder

--- a/gr-starcoder/lib/waterfall_plotter_impl.h
+++ b/gr-starcoder/lib/waterfall_plotter_impl.h
@@ -23,6 +23,7 @@
 
 #include <list>
 #include <starcoder/waterfall_plotter.h>
+#include <string_queue.h>
 
 namespace gr {
   namespace starcoder {
@@ -42,6 +43,7 @@ namespace gr {
       char* filename_;
       size_t fft_size_;
       void init_numpy_array();
+      string_queue *string_queue_;
 
      public:
       waterfall_plotter_impl(double samp_rate, double center_freq,
@@ -54,6 +56,8 @@ namespace gr {
          gr_vector_void_star &output_items);
 
       virtual bool stop();
+
+      void register_queue_pointer(uint64_t ptr);
     };
 
   } // namespace starcoder

--- a/gr-starcoder/python/plot_waterfall.py
+++ b/gr-starcoder/python/plot_waterfall.py
@@ -107,8 +107,8 @@ def plot_waterfall(arr, samp_rate, center_freq, rps, fft, filename):
     plt.ylabel('Time (seconds)')
 
     if filename != '':
-        plt.savefig(filename, bbox_inches='tight', pad_inches=0.2)
+        plt.savefig(filename, bbox_inches='tight', pad_inches=0.2, format='png')
 
     buf = io.BytesIO()
-    plt.savefig(buf, bbox_inches='tight', pad_inches=0, format='png')
+    plt.savefig(buf, bbox_inches='tight', pad_inches=0.2, format='png')
     return buf.getvalue()

--- a/gr-starcoder/python/waterfall_sink.py
+++ b/gr-starcoder/python/waterfall_sink.py
@@ -70,8 +70,11 @@ class waterfall_sink(gr.hier_block2):
 
         waterfall_heatmap = starcoder_swig.waterfall_heatmap(samp_rate, center_freq, rps, fft_size, mode)
         s2v = blocks.stream_to_vector(gr.sizeof_gr_complex, fft_size)
-        waterfall_pl = starcoder_swig.waterfall_plotter(samp_rate, center_freq, rps, fft_size, filename)
+        self.waterfall_pl = starcoder_swig.waterfall_plotter(samp_rate, center_freq, rps, fft_size, filename)
 
         self.connect((self, 0), (s2v, 0))
         self.connect((s2v, 0), (waterfall_heatmap, 0))
-        self.connect((waterfall_heatmap, 0), (waterfall_pl, 0))
+        self.connect((waterfall_heatmap, 0), (self.waterfall_pl, 0))
+
+    def register_queue_pointer(self, ptr):
+        self.waterfall_pl.register_queue_pointer(ptr)

--- a/gr-starcoder/python/waterfall_sink.py
+++ b/gr-starcoder/python/waterfall_sink.py
@@ -76,5 +76,5 @@ class waterfall_sink(gr.hier_block2):
         self.connect((s2v, 0), (waterfall_heatmap, 0))
         self.connect((waterfall_heatmap, 0), (self.waterfall_pl, 0))
 
-    def register_queue_pointer(self, ptr):
-        self.waterfall_pl.register_queue_pointer(ptr)
+    def register_starcoder_queue(self, ptr):
+        self.waterfall_pl.register_starcoder_queue(ptr)

--- a/sampleclient/main.go
+++ b/sampleclient/main.go
@@ -24,6 +24,7 @@ import (
 	pb "github.com/infostellarinc/starcoder/api"
 	"google.golang.org/grpc"
 	"io"
+	"io/ioutil"
 	"log"
 	"time"
 )
@@ -50,6 +51,9 @@ func main() {
 				log.Fatalf("%v", err)
 			}
 			log.Println(r.GetBlockId(), r.GetPayload())
+			if r.GetBlockId() == "starcoder_waterfall_sink_0" {
+				ioutil.WriteFile("/home/rei/sampleAR2300IQ/waterfall_rec.png", r.GetPayload(), 0644)
+			}
 		}
 	}()
 	req := &pb.RunFlowgraphRequest{
@@ -64,7 +68,7 @@ func main() {
 			{
 				Key: "waterfall_image_file_path",
 				Value: &pb.Value{
-					Val: &pb.Value_StringValue{StringValue: "/home/rei/sampleAR2300IQ/waterfall"},
+					Val: &pb.Value_StringValue{StringValue: "/home/rei/sampleAR2300IQ/waterfall.png"},
 				},
 			},
 		},

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -481,13 +481,13 @@ func (s *Starcoder) startFlowGraph(modAndImport *moduleAndClassNames, request *p
 			val := python.PyString_FromString("")
 			defer val.DecRef()
 			for python.PyDict_Next(flowGraphDict, &iter, &key, &val) {
-				// Verify instance has register_queue_pointer
-				hasStarcoderObserve := val.HasAttrString("register_queue_pointer")
+				// Verify instance has register_starcoder_queue
+				hasStarcoderObserve := val.HasAttrString("register_starcoder_queue")
 				if hasStarcoderObserve == 1 {
 					k := python.PyString_AsString(key)
 					newQ := cqueue.NewCStringQueue(defaultQueueSize)
 					pyQPtr := python.PyLong_FromUnsignedLongLong(newQ.GetPtr())
-					result := val.CallMethodObjArgs("register_queue_pointer", pyQPtr)
+					result := val.CallMethodObjArgs("register_starcoder_queue", pyQPtr)
 					pyQPtr.DecRef()
 					if result == nil {
 						newQ.Close()
@@ -496,7 +496,7 @@ func (s *Starcoder) startFlowGraph(modAndImport *moduleAndClassNames, request *p
 					}
 					observableCQueue[k] = newQ
 					result.DecRef()
-					fmt.Println("found block with register_queue_pointer:", k)
+					fmt.Println("found block with register_starcoder_queue:", k)
 				}
 			}
 		}


### PR DESCRIPTION
Adds `register_queue_pointer` method to waterfall plotter and sends back final waterfall plot via `string_queue` (if registered).

Also adds a lock around `string_queue.push()` as per https://github.com/infostellarinc/starcoder/pull/33#discussion_r185179199
