### PR TITLE
Don't delete the GTK mock after setup since it is still needed when r…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,7 +323,6 @@ task setupPrefix(type: Exec) {
     }
 
     doLast {
-        delete "${gnuradioRoot}/lib/python2.7/site-packages/gtk"
         delete "${gnuradioRoot}/pkgs"
         delete "${gnuradioRoot}/src"
     }

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -10,7 +10,5 @@ COPY --from=0 /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio /roo
 
 ADD ./tools/builder/run.sh /usr/bin/run-starcoder
 
-ENV GRC_BLOCKS_PATH /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/share/gnuradio/grc/blocks
-
 ENTRYPOINT [ "run-starcoder" ]
 CMD [ "serve" ]


### PR DESCRIPTION
…unning GRCC even for non-gui graphs.

Also don't set the grc blocks env variable since it doesn't seem to be needed.