### PR TITLE
Update Circle cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies
+          - v1.1-dependencies
 
       - run: ./gradlew --no-daemon install
 
       - save_cache:
           paths:
             - ~/.gradle
-          key: v1-dependencies
+          key: v1.1-dependencies


### PR DESCRIPTION
Seems that "build without cache" doesn't re-save the cache. Not sure if bug or feature. See https://discuss.circleci.com/t/does-clear-cache-work-for-2-0/10965/22 particularly the February posts.

The [official docs](https://support.circleci.com/hc/en-us/articles/115015426888-Clear-project-cache) suggest that we just change the cache version everytime we want to clear the cache, so I guess this works.