### PR TITLE
Turn on Perf counter env variable

### DIFF
--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -19,5 +19,7 @@ COPY --from=0 /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio /roo
 
 ADD ./tools/builder/run.sh /usr/bin/run-starcoder
 
+ENV GR_CONF_PERFCOUNTERS_ON True
+
 ENTRYPOINT [ "run-starcoder" ]
 CMD [ "serve" ]


### PR DESCRIPTION
We still need to explicitly turn on the GNURadio performance counter in the runtime config. We can do this either with an environment variable or `$HOME/.gnuradio/config.conf`. I wasn't sure which was the best way to do this.