### PR TITLE
STELLAR-1256 Add debug logs for unexpected packets > 10MB

### DIFF
--- a/cqueue/string_queue.cc
+++ b/cqueue/string_queue.cc
@@ -18,6 +18,7 @@
  */
 
 #include "string_queue.h"
+#include <iostream>
 
 string_queue::string_queue(int buffer_size)
     : queue_(buffer_size), closed_(false) {}
@@ -34,6 +35,10 @@ void string_queue::push(const std::string &item) {
 std::string string_queue::pop() {
   std::string a;
   queue_.pop(a);
+  if (a.length() > 10485760) {
+    std::cerr << "Popped large packet of length " << a.length() << " from string_queue::pop\n";
+    return "";
+  }
   return a;
 }
 
@@ -44,6 +49,10 @@ std::string string_queue::blocking_pop() {
     return (!queue_.empty() || closed_);
   });
   queue_.pop(a);
+  if (a.length() > 10485760) {
+    std::cerr << "Popped large packet of length " << a.length() << " from string_queue::blocking_pop\n";
+    return "";
+  }
   return a;
 }
 

--- a/cqueue/string_queue.cc
+++ b/cqueue/string_queue.cc
@@ -36,7 +36,8 @@ std::string string_queue::pop() {
   std::string a;
   queue_.pop(a);
   if (a.length() > 10485760) {
-    std::cerr << "Popped large packet of length " << a.length() << " from string_queue::pop\n";
+    std::cerr << "Popped large packet of length " << a.length()
+              << " from string_queue::pop\n";
     return "";
   }
   return a;
@@ -50,7 +51,8 @@ std::string string_queue::blocking_pop() {
   });
   queue_.pop(a);
   if (a.length() > 10485760) {
-    std::cerr << "Popped large packet of length " << a.length() << " from string_queue::blocking_pop\n";
+    std::cerr << "Popped large packet of length " << a.length()
+              << " from string_queue::blocking_pop\n";
     return "";
   }
   return a;

--- a/gr-starcoder/lib/enqueue_message_sink_impl.cc
+++ b/gr-starcoder/lib/enqueue_message_sink_impl.cc
@@ -54,7 +54,9 @@ void enqueue_message_sink_impl::handler(pmt::pmt_t msg) {
     std::string serialized = pmt::serialize_str(msg);
     if (serialized.length() > 10485760) {
       GR_LOG_ERROR(d_logger,
-      boost::format("Received large packet of length %d in enqueue_message_sink_impl::handler") % serialized.length());
+                   boost::format("Received large packet of length %d in "
+                                 "enqueue_message_sink_impl::handler") %
+                       serialized.length());
       return;
     }
     string_queue_->push(serialized);

--- a/gr-starcoder/lib/enqueue_message_sink_impl.cc
+++ b/gr-starcoder/lib/enqueue_message_sink_impl.cc
@@ -51,7 +51,13 @@ enqueue_message_sink_impl::~enqueue_message_sink_impl() {}
 
 void enqueue_message_sink_impl::handler(pmt::pmt_t msg) {
   if (string_queue_ != NULL) {
-    string_queue_->push(pmt::serialize_str(msg));
+    std::string serialized = pmt::serialize_str(msg);
+    if (serialized.length() > 10485760) {
+      GR_LOG_ERROR(d_logger,
+      boost::format("Received large packet of length %d in enqueue_message_sink_impl::handler") % serialized.length());
+      return;
+    }
+    string_queue_->push(serialized);
   }
 }
 

--- a/gr-starcoder/lib/noaa_apt_sink_impl.cc
+++ b/gr-starcoder/lib/noaa_apt_sink_impl.cc
@@ -127,9 +127,11 @@ void noaa_apt_sink_impl::write_image(std::string filename) {
   }
 
   if (string_queue_ != NULL) {
-    // TODO: Writes out to /tmp since Boost GIL doesn't support writing to streams.
+    // TODO: Writes out to /tmp since Boost GIL doesn't support writing to
+    // streams.
     // This should be fixed moving forward
-    boost::filesystem::path temp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    boost::filesystem::path temp = boost::filesystem::temp_directory_path() /
+                                   boost::filesystem::unique_path();
 
     boost::gil::detail::png_writer writer(temp.native().c_str());
 


### PR DESCRIPTION
Adds error logs so we can narrow down at which stage this bug (unexpected packet > 10MB) happens. Once it is caught, it is not sent through gRPC so the stream can continue.