### PR TITLE
fix boost 1.67.0 build failure

### DIFF
--- a/cqueue/string_queue.h
+++ b/cqueue/string_queue.h
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <string>
+#include <boost/next_prior.hpp>
 #include <boost/lockfree/spsc_queue.hpp>
 /*
 This class is a threadsafe single-producer single-consumer queue

--- a/gr-starcoder/lib/blocking_spsc_queue.h
+++ b/gr-starcoder/lib/blocking_spsc_queue.h
@@ -23,6 +23,7 @@
 #ifdef __cplusplus
 #include <mutex>
 #include <condition_variable>
+#include <boost/next_prior.hpp>
 #include <boost/lockfree/spsc_queue.hpp>
 class blocking_spsc_queue {
  public:


### PR DESCRIPTION
Similar issues here. 
https://github.com/MusicPlayerDaemon/MPD/issues/265
https://github.com/MusicPlayerDaemon/MPD/pull/266
https://github.com/Homebrew/homebrew-core/pull/26784

It looks like boost 1.67.0 has the bug. What I'm wondering is what triggered the change of version of boost in our build? It doesn't seem like https://github.com/gnuradio/gr-recipes/blob/master/boost.lwr changed (I'm assuming this is what defines the version of boost we use?).