### PR TITLE
Modify transceiver flowgraph

### DIFF
--- a/flowgraphs/fsk_9600_ax25_transceiver.grc
+++ b/flowgraphs/fsk_9600_ax25_transceiver.grc
@@ -1252,7 +1252,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>50000</value>
+      <value>30000</value>
     </param>
   </block>
   <block>
@@ -2899,7 +2899,7 @@
     </param>
     <param>
       <key>dev_addr</key>
-      <value>"serial=" + transmitter_serial</value>
+      <value>("serial=" + transmitter_serial) if transmitter_serial else ""</value>
     </param>
     <param>
       <key>dev_args</key>
@@ -4234,7 +4234,7 @@
     </param>
     <param>
       <key>dev_addr</key>
-      <value>"serial=" + receiver_serial</value>
+      <value>("serial=" + receiver_serial) if receiver_serial else ""</value>
     </param>
     <param>
       <key>dev_args</key>

--- a/flowgraphs/fsk_9600_ax25_transceiver.grc
+++ b/flowgraphs/fsk_9600_ax25_transceiver.grc
@@ -1726,7 +1726,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>30F9A7C</value>
+      <value></value>
     </param>
   </block>
   <block>
@@ -2236,7 +2236,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>314FC27</value>
+      <value></value>
     </param>
   </block>
   <block>


### PR DESCRIPTION
Previously we were going to use 2 USRPs per groundstation so it wasn't a big issue that the serial numbers were required. This change modifies the flowgraph to work with a blank serial device, defaulting to the first USRP it sees.

Also, I overshot on the default frequency offset so I changed it from 50k to 30k.