### PR TITLE
STELLAR-1570 run uhd images downloader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1.4-dependencies
+          - v1.5-dependencies
 
       - run:
           command: ./gradlew --no-daemon install
@@ -36,4 +36,4 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: v1.4-dependencies
+          key: v1.5-dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -312,7 +312,8 @@ task setupPrefix(type: Exec) {
     args '-c', condaCommand("""pybombs auto-config && \\
         pybombs -y recipes add-defaults && \\
         pybombs -y recipes add gr-starcoder ${project.file('gr-recipes')} && \\
-        pybombs -y -v prefix init ${gnuradioRoot} -a gnuradio -R gnuradio-nogui
+        pybombs -y -v prefix init ${gnuradioRoot} -a gnuradio -R gnuradio-nogui && \\
+        ${gnuradioRoot}/lib/uhd/utils/uhd_images_downloader.py
     """)
     // For some reason, cmake has trouble finding boost in certain situations.
     environment 'BOOST_ROOT', gnuradioRoot


### PR DESCRIPTION
UHD needs to download some additional images after installation to properly operate the USRP. We did this by directly running
`/root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio/lib/uhd/utils/uhd_images_downloader.py`
in the image.

Dunno if it'll work, let's see what Circle does.