### PR TITLE
Add configuration for suppressing particular command logs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ func initConfig() {
 		viper.SetConfigName("config")
 	}
 
+	viper.SetEnvPrefix("starcoder")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -54,6 +54,7 @@ type serveCmdConfiguration struct {
 	FlowgraphDir              string
 	ExporterAddress           string
 	PerfCtrCollectionInterval time.Duration
+	SilencedCommandBlocks     []string
 }
 
 var serveCmdConfig = serveCmdConfiguration{}
@@ -71,6 +72,7 @@ var serveCmd = &cobra.Command{
 		log := l.Sugar()
 		defer log.Sync()
 
+		log.Infof("Using configuration: %+v", serveCmdConfig)
 		log.Infof("serve called, using bind address %v", serveCmdConfig.BindAddress)
 
 		// Set up metrics endpoint
@@ -122,7 +124,7 @@ var serveCmd = &cobra.Command{
 				grpc_zap.StreamServerInterceptor(l),
 			),
 		)
-		starcoder := server.NewStarcoderServer(serveCmdConfig.FlowgraphDir, serveCmdConfig.PerfCtrCollectionInterval, log, metrics)
+		starcoder := server.NewStarcoderServer(serveCmdConfig.FlowgraphDir, serveCmdConfig.PerfCtrCollectionInterval, serveCmdConfig.SilencedCommandBlocks, log, metrics)
 
 		// Handle OS signals
 		sigs := make(chan os.Signal, 1)
@@ -171,6 +173,7 @@ func init() {
 	serveCmd.Flags().StringVar(&serveCmdConfig.FlowgraphDir, "flowgraph-dir", "", "Directory containing GNURadio flowgraphs to serve. If blank, defaults to built-in Starcoder flowgraphs.")
 	serveCmd.Flags().StringVar(&serveCmdConfig.ExporterAddress, "exporter-address", defaultExporterAddress, "Address where exported Prometheus metrics will be served")
 	serveCmd.Flags().DurationVar(&serveCmdConfig.PerfCtrCollectionInterval, "perf-ctr-interval", defaultPerfCtrCollectionInterval, "Time interval for exporting GNURadio performance metrics to Prometheus. If set to 0, this will be disabled. Default 15s.")
+	serveCmd.Flags().StringSliceVar(&serveCmdConfig.SilencedCommandBlocks, "silenced-command-blocks", []string{}, "Each command sent to a block in Starcoder is logged to the output. This can be too much for blocks that receive commands multiple times a second e.g. Doppler shift blocks. You can provide a list of comma-separated strings to this variable to silence command logging for the block e.g. \"doppler_command_source,doppler_command_source_transmit\"")
 
 	viper.BindPFlags(serveCmd.Flags())
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -169,11 +169,11 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	serveCmd.Flags().StringVar(&serveCmdConfig.BindAddress, "bind-address", defaultBindAddress, "Address to bind to")
-	serveCmd.Flags().StringVar(&serveCmdConfig.FlowgraphDir, "flowgraph-dir", "", "Directory containing GNURadio flowgraphs to serve. If blank, defaults to built-in Starcoder flowgraphs.")
-	serveCmd.Flags().StringVar(&serveCmdConfig.ExporterAddress, "exporter-address", defaultExporterAddress, "Address where exported Prometheus metrics will be served")
-	serveCmd.Flags().DurationVar(&serveCmdConfig.PerfCtrCollectionInterval, "perf-ctr-interval", defaultPerfCtrCollectionInterval, "Time interval for exporting GNURadio performance metrics to Prometheus. If set to 0, this will be disabled. Default 15s.")
-	serveCmd.Flags().StringSliceVar(&serveCmdConfig.SilencedCommandBlocks, "silenced-command-blocks", []string{}, "Each command sent to a block in Starcoder is logged to the output. This can be too much for blocks that receive commands multiple times a second e.g. Doppler shift blocks. You can provide a list of comma-separated strings to this variable to silence command logging for the block e.g. \"doppler_command_source,doppler_command_source_transmit\"")
+	serveCmd.Flags().StringVar(&serveCmdConfig.BindAddress, "bind_address", defaultBindAddress, "Address to bind to")
+	serveCmd.Flags().StringVar(&serveCmdConfig.FlowgraphDir, "flowgraph_dir", "", "Directory containing GNURadio flowgraphs to serve. If blank, defaults to built-in Starcoder flowgraphs.")
+	serveCmd.Flags().StringVar(&serveCmdConfig.ExporterAddress, "exporter_address", defaultExporterAddress, "Address where exported Prometheus metrics will be served")
+	serveCmd.Flags().DurationVar(&serveCmdConfig.PerfCtrCollectionInterval, "perf_ctr_interval", defaultPerfCtrCollectionInterval, "Time interval for exporting GNURadio performance metrics to Prometheus. If set to 0, this will be disabled. Default 15s.")
+	serveCmd.Flags().StringSliceVar(&serveCmdConfig.SilencedCommandBlocks, "silenced_command_blocks", []string{}, "Each command sent to a block in Starcoder is logged to the output. This can be too much for blocks that receive commands multiple times a second e.g. Doppler shift blocks. You can provide a list of comma-separated strings to this variable to silence command logging for the block e.g. \"doppler_command_source,doppler_command_source_transmit\"")
 
 	viper.BindPFlags(serveCmd.Flags())
 }

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=0 /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio /roo
 ADD ./tools/builder/run.sh /usr/bin/run-starcoder
 
 ENV GR_CONF_PERFCOUNTERS_ON True
-ENV STARCODER_SILENCED-COMMAND-BLOCKS doppler_command_source,doppler_command_source_transmit
+ENV STARCODER_SILENCED_COMMAND_BLOCKS doppler_command_source,doppler_command_source_transmit
 
 ENTRYPOINT [ "run-starcoder" ]
 CMD [ "serve" ]

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=0 /root/.gradle/curiostack/python/bootstrap/miniconda2-gnuradio /roo
 ADD ./tools/builder/run.sh /usr/bin/run-starcoder
 
 ENV GR_CONF_PERFCOUNTERS_ON True
+ENV STARCODER_SILENCED-COMMAND-BLOCKS doppler_command_source,doppler_command_source_transmit
 
 ENTRYPOINT [ "run-starcoder" ]
 CMD [ "serve" ]


### PR DESCRIPTION
Logging that a certain block in Starcoder received a command is very useful, but for blocks like Doppler shift which receive a command hundreds of times a second, very spammy. This PR adds a configuration option to silence logs for a particular command block.