### PR TITLE
install git on builder

### DIFF
--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -9,6 +9,8 @@ ADD mockpygtk /workspace/gnuradio/mockpygtk
 
 RUN cd /workspace/gnuradio && ./gradlew setupPrefix
 
+RUN apt-get -y update && apt-get -y install git
+
 ADD . /workspace/starcoder
 
 RUN cd /workspace/starcoder && ./gradlew install


### PR DESCRIPTION
Dunno if this is the correct solution, but I noticed the Circle Docker image installs git while tools/builder/Dockerfile doesn't.