### PR TITLE
Add a recipe for pybombs user to install gr-starcoder.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,6 +286,19 @@ task installGrStarcoder(type: org.curioswitch.gradle.conda.tasks.CondaExecTask) 
     }
 }
 
+task installGrStarcoderFromRecipe(type: org.curioswitch.gradle.conda.tasks.CondaExecTask) {
+    dependsOn setupPrefix
+
+    condaName 'gnuradio'
+
+    command 'pybombs -y install gr-starcoder'
+
+    execCustomizer {exec->
+        exec.environment 'PKG_CONFIG_PATH', "${gnuradioRoot}/lib/pkgconfig"
+        exec.environment 'PYBOMBS_PREFIX', gnuradioRoot
+    }
+}
+
 task installStarcoder(type: Copy) {
     dependsOn build
     from 'build/exe/current'

--- a/gr-recipes/gr-starcoder.lwr
+++ b/gr-recipes/gr-starcoder.lwr
@@ -1,0 +1,27 @@
+#
+# Starcoder - a server to read/write data from/to the stars, written in Go.
+# Copyright (C) 2018 InfoStellar, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+category: common
+description: Out-of-tree Module for gr-starcoder
+gitbranch: master
+inherit: cmake
+source: git+https://github.com/infostellarinc/starcoder.git
+configuredir: gr-starcoder/build
+makedir: gr-starcoder/build
+installdir: gr-starcoder/build


### PR DESCRIPTION
Just needed to set `PYBOMBS_PREFIX`.

Also created a separate gradle task for now since installing with this command currently can only build our merged code, not unmerged code which we need for PR builds. I think we can override to use a local directory in `gnuradio-nogui.lwr` but haven't looked into it yet.