### PR TITLE
Fix grc compile bug for AAUSAT decoder

### DIFF
--- a/flowgraphs/aausat4.grc
+++ b/flowgraphs/aausat4.grc
@@ -97,33 +97,6 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 732)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>MTU</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>1500</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
       <value>1</value>
     </param>
     <param>
@@ -388,7 +361,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 796)</value>
+      <value>(8, 812)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -401,6 +374,53 @@
     <param>
       <key>value</key>
       <value>"/home/rei/sampleAR2300IQ/full.bin"</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(8, 732)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>MTU</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value></value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>hide</key>
+      <value>none</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>1500</value>
     </param>
   </block>
   <block>
@@ -698,7 +718,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1624,7 +1644,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1655,7 +1675,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1686,7 +1706,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1717,7 +1737,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1748,7 +1768,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1779,7 +1799,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>1</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -2296,7 +2316,7 @@ we're getting are inverted</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 860)</value>
+      <value>(8, 876)</value>
     </param>
     <param>
       <key>_rotation</key>


### PR DESCRIPTION
No change except MTU is now a parameter instead of a variable. For some reason, grcc won't compile if CC Decoder Definition block uses a variable, but has no problem with a parameter..