### PR TITLE
fix build failures on some systems

### DIFF
--- a/gr-starcoder/CMakeLists.txt
+++ b/gr-starcoder/CMakeLists.txt
@@ -24,6 +24,10 @@ cmake_minimum_required(VERSION 2.6)
 project(gr-starcoder CXX C)
 enable_testing()
 
+# Enable C++11 support
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 #install to PyBOMBS target prefix if defined
 if(DEFINED ENV{PYBOMBS_PREFIX})
     set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})

--- a/gr-starcoder/lib/gil_util.cc
+++ b/gr-starcoder/lib/gil_util.cc
@@ -21,6 +21,7 @@
 #include "gil_util.h"
 
 #include <memory>
+#include <fstream>
 
 namespace gr {
 namespace starcoder {

--- a/gr-starcoder/lib/meteor_decoder_sink_impl.cc
+++ b/gr-starcoder/lib/meteor_decoder_sink_impl.cc
@@ -22,6 +22,8 @@
 #include "config.h"
 #endif
 
+#include <fstream>
+
 #include <gnuradio/io_signature.h>
 #include "meteor_decoder_sink_impl.h"
 


### PR DESCRIPTION
Roger's build failed until we added these lines.

The lines in CMakeLists.txt were needed to fix this error:
```
[  1%] Building CXX object lib/CMakeFiles/gnuradio-starcoder.dir/home/user/starcoder/cqueue/string_queue.cc.o
In file included from /usr/include/c++/5/mutex:35:0,
                 from /home/user/starcoder/cqueue/string_queue.h:20,
                 from /home/user/starcoder/cqueue/string_queue.cc:20:
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^
In file included from /home/user/starcoder/cqueue/string_queue.cc:20:0:
/home/user/starcoder/cqueue/string_queue.h:50:10: error: ‘condition_variable’ in namespace ‘std’ does not name a type
     std::condition_variable condition_var_;
          ^
/home/user/starcoder/cqueue/string_queue.h:51:10: error: ‘mutex’ in namespace ‘std’ does not name a type
     std::mutex mutex_;
          ^
/home/user/starcoder/cqueue/string_queue.cc: In member function ‘void string_queue::push(const string&)’:
/home/user/starcoder/cqueue/string_queue.cc:27:3: error: ‘unique_lock’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
   ^
/home/user/starcoder/cqueue/string_queue.cc:27:20: error: ‘mutex’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
                    ^
/home/user/starcoder/cqueue/string_queue.cc:27:37: error: ‘mutex_’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                     ^
/home/user/starcoder/cqueue/string_queue.cc:27:43: error: ‘lock’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                           ^
/home/user/starcoder/cqueue/string_queue.cc:31:5: error: ‘condition_var_’ was not declared in this scope
     condition_var_.notify_one();
     ^
/home/user/starcoder/cqueue/string_queue.cc: In member function ‘std::__cxx11::string string_queue::blocking_pop()’:
/home/user/starcoder/cqueue/string_queue.cc:48:3: error: ‘unique_lock’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
   ^
/home/user/starcoder/cqueue/string_queue.cc:48:20: error: ‘mutex’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
                    ^
/home/user/starcoder/cqueue/string_queue.cc:48:37: error: ‘mutex_’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                     ^
/home/user/starcoder/cqueue/string_queue.cc:48:43: error: ‘lock’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                           ^
/home/user/starcoder/cqueue/string_queue.cc:49:3: error: ‘condition_var_’ was not declared in this scope
   condition_var_.wait(lock, [this] {
   ^
/home/user/starcoder/cqueue/string_queue.cc:51:3: warning: lambda expressions only available with -std=c++11 or -std=gnu++11
   });
   ^
/home/user/starcoder/cqueue/string_queue.cc: In member function ‘void string_queue::close()’:
/home/user/starcoder/cqueue/string_queue.cc:62:3: error: ‘unique_lock’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
   ^
/home/user/starcoder/cqueue/string_queue.cc:62:20: error: ‘mutex’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
                    ^
/home/user/starcoder/cqueue/string_queue.cc:62:37: error: ‘mutex_’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                     ^
/home/user/starcoder/cqueue/string_queue.cc:62:43: error: ‘lock’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                           ^
/home/user/starcoder/cqueue/string_queue.cc:65:3: error: ‘condition_var_’ was not declared in this scope
   condition_var_.notify_one();
   ^
/home/user/starcoder/cqueue/string_queue.cc: In member function ‘bool string_queue::closed()’:
/home/user/starcoder/cqueue/string_queue.cc:69:3: error: ‘unique_lock’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
   ^
/home/user/starcoder/cqueue/string_queue.cc:69:20: error: ‘mutex’ is not a member of ‘std’
   std::unique_lock<std::mutex> lock(mutex_);
                    ^
/home/user/starcoder/cqueue/string_queue.cc:69:37: error: ‘mutex_’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                     ^
/home/user/starcoder/cqueue/string_queue.cc:69:43: error: ‘lock’ was not declared in this scope
   std::unique_lock<std::mutex> lock(mutex_);
                                           ^
lib/CMakeFiles/gnuradio-starcoder.dir/build.make:70: recipe for target 'lib/CMakeFiles/gnuradio-starcoder.dir/home/user/starcoder/cqueue/string_queue.cc.o' failed
make[2]: *** [lib/CMakeFiles/gnuradio-starcoder.dir/home/user/starcoder/cqueue/string_queue.cc.o] Error 1
CMakeFiles/Makefile2:137: recipe for target 'lib/CMakeFiles/gnuradio-starcoder.dir/all' failed
make[1]: *** [lib/CMakeFiles/gnuradio-starcoder.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```


The lines including <fstream> were needed to fix this error:
```
/home/user/starcoder/gr-starcoder/lib/gil_util.cc: In function ‘std::__cxx11::string gr::starcoder::store_rgb_to_png_string(boost::gil::image<boost::gil::pixel<unsigned char, boost::gil::layout<boost::mpl::vector3<boost::gil::red_t, boost::gil::green_t, boost::gil::blue_t> > >, false, std::allocator<unsigned char> >::view_t)’:
/home/user/starcoder/gr-starcoder/lib/gil_util.cc:40:19: error: variable ‘std::ifstream t’ has initializer but incomplete type
   std::ifstream t(temp.native(), std::ios::binary);
                   ^
/home/user/starcoder/gr-starcoder/lib/gil_util.cc: In function ‘std::__cxx11::string gr::starcoder::store_gray_to_png_string(boost::gil::image<boost::gil::pixel<unsigned char, boost::gil::layout<boost::mpl::vector1<boost::gil::gray_color_t> > >, false, std::allocator<unsigned char> >::view_t)’:
/home/user/starcoder/gr-starcoder/lib/gil_util.cc:60:19: error: variable ‘std::ifstream t’ has initializer but incomplete type
   std::ifstream t(temp.native(), std::ios::binary);
                   ^
lib/CMakeFiles/gnuradio-starcoder.dir/build.make:406: recipe for target 'lib/CMakeFiles/gnuradio-starcoder.dir/gil_util.cc.o' failed
make[2]: *** [lib/CMakeFiles/gnuradio-starcoder.dir/gil_util.cc.o] Error 1
CMakeFiles/Makefile2:137: recipe for target 'lib/CMakeFiles/gnuradio-starcoder.dir/all' failed
make[1]: *** [lib/CMakeFiles/gnuradio-starcoder.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2
```

The weird thing is my build (and obviously our CI build) works with or without those lines.. Not sure if I should merge this in anyway.