### PR TITLE
Copy only needed files to starcoder image.

### DIFF
--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -15,7 +15,20 @@ RUN cd /workspace/starcoder && ./gradlew install
 
 FROM debian:9-slim
 
-COPY --from=0 /root/.gradle/curiostack/gnuradio /root/.gradle/curiostack/gnuradio
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/etc /root/.gradle/curiostack/gnuradio/4.4.10/etc
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/lib /root/.gradle/curiostack/gnuradio/4.4.10/lib
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/lib64 /root/.gradle/curiostack/gnuradio/4.4.10/lib64
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/share/gnuradio /root/.gradle/curiostack/gnuradio/4.4.10/share/gnuradio
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/share/uhd /root/.gradle/curiostack/gnuradio/4.4.10/share/uhd
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/ssl /root/.gradle/curiostack/gnuradio/4.4.10/ssl
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/x86_64-conda_cos6-linux-gnu /root/.gradle/curiostack/gnuradio/4.4.10/x86_64-conda_cos6-linux-gnu
+
+
+COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/bin/conda \
+  /root/.gradle/curiostack/gnuradio/4.4.10/bin/python* \
+  /root/.gradle/curiostack/gnuradio/4.4.10/bin/grcc \
+  /root/.gradle/curiostack/gnuradio/4.4.10/bin/starcoder \
+  /root/.gradle/curiostack/gnuradio/4.4.10/bin/
 
 ADD ./tools/builder/run.sh /usr/bin/run-starcoder
 


### PR DESCRIPTION
I verified that starcoder starts up but it's hard to actually be confident without also checking a flowgraph.

The raw image goes from 3.5G to 2.9G. I didn't check compressed size, but I guess the difference is much less since much of what's left out is files like `docs`.