### PR TITLE
fsk demodulator fix init

### DIFF
--- a/flowgraphs/fsk_9600.grc
+++ b/flowgraphs/fsk_9600.grc
@@ -10,7 +10,7 @@
     </param>
     <param>
       <key>window_size</key>
-      <value></value>
+      <value>(1500, 1250)</value>
     </param>
     <param>
       <key>category</key>
@@ -101,7 +101,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 396)</value>
+      <value>(8, 372)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -128,7 +128,34 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 332)</value>
+      <value>(8, 508)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>nfilts</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>16</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(80, 508)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -136,11 +163,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>fsk_deviation_hz</value>
+      <value>rrc_taps</value>
     </param>
     <param>
       <key>value</key>
-      <value>10e3</value>
+      <value>firdes.root_raised_cosine(nfilts, nfilts*sps, 1, 0.35, 11*sps*nfilts)</value>
     </param>
   </block>
   <block>
@@ -155,61 +182,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 268)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>lpf_cutoff</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>8000</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 204)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>lpf_decim</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>10</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(8, 460)</value>
+      <value>(8, 436)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -222,6 +195,60 @@
     <param>
       <key>value</key>
       <value>"/home/rei/sampleAR2300IQ/full.bin"</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(104, 572)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>sps</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>int(round(float(target_samp_rate)/baud_rate))</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(8, 572)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>sps_float</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>float(target_samp_rate)/baud_rate</value>
     </param>
   </block>
   <block>
@@ -244,7 +271,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(456, 388)</value>
+      <value>(464, 420)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -252,7 +279,7 @@
     </param>
     <param>
       <key>gain</key>
-      <value>target_samp_rate/(20*math.pi*fsk_deviation_hz/8.0)</value>
+      <value>target_samp_rate/(20*math.pi*baud_rate/8.0)</value>
     </param>
     <param>
       <key>id</key>
@@ -265,6 +292,108 @@
     <param>
       <key>minoutbuf</key>
       <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_add_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1e-20</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1104, 452)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_add_const_vxx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_divide_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1280, 424)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_divide_xx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
     </param>
   </block>
   <block>
@@ -327,6 +456,104 @@
     </param>
   </block>
   <block>
+    <key>blocks_multiply_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1.0/1</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(952, 452)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_multiply_const_vxx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_rms_xx</key>
+    <param>
+      <key>alpha</key>
+      <value>.01</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(816, 452)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_rms_xx_1</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
     <key>blocks_throttle</key>
     <param>
       <key>alias</key>
@@ -346,7 +573,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(456, 28)</value>
+      <value>(464, 28)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -401,7 +628,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(672, 380)</value>
+      <value>(648, 412)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -448,7 +675,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 668)</value>
+      <value>(8, 876)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -499,7 +726,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(456, 544)</value>
+      <value>(896, 720)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -519,7 +746,7 @@
     </param>
   </block>
   <block>
-    <key>digital_clock_recovery_mm_xx</key>
+    <key>digital_symbol_sync_xx</key>
     <param>
       <key>alias</key>
       <value></value>
@@ -533,52 +760,76 @@
       <value></value>
     </param>
     <param>
+      <key>damping</key>
+      <value>.2</value>
+    </param>
+    <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>True</value>
+    </param>
+    <param>
+      <key>ted_gain</key>
+      <value>0.09501613+1.32802387/(1+(sps_float/28.7271)**2.541608)</value>
+    </param>
+    <param>
+      <key>nfilters</key>
+      <value>nfilts</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(248, 508)</value>
+      <value>(440, 620)</value>
     </param>
     <param>
       <key>_rotation</key>
       <value>0</value>
     </param>
     <param>
-      <key>gain_mu</key>
-      <value>0.175</value>
-    </param>
-    <param>
-      <key>gain_omega</key>
-      <value>0.25*0.175*0.175</value>
+      <key>type</key>
+      <value>ff</value>
     </param>
     <param>
       <key>id</key>
-      <value>digital_clock_recovery_mm_xx_0</value>
+      <value>digital_symbol_sync_xx_0</value>
+    </param>
+    <param>
+      <key>resamp_type</key>
+      <value>digital.IR_PFB_MF</value>
+    </param>
+    <param>
+      <key>loop_bw</key>
+      <value>3.1416/10</value>
     </param>
     <param>
       <key>maxoutbuf</key>
       <value>0</value>
     </param>
     <param>
+      <key>max_dev</key>
+      <value>0.01</value>
+    </param>
+    <param>
       <key>minoutbuf</key>
       <value>0</value>
     </param>
     <param>
-      <key>mu</key>
-      <value>0.5</value>
+      <key>osps</key>
+      <value>1</value>
     </param>
     <param>
-      <key>omega_relative_limit</key>
-      <value>0.005</value>
+      <key>pfb_mf_taps</key>
+      <value>rrc_taps</value>
     </param>
     <param>
-      <key>omega</key>
-      <value>4</value>
+      <key>sps</key>
+      <value>sps_float</value>
     </param>
     <param>
-      <key>type</key>
-      <value>float</value>
+      <key>constellation</key>
+      <value>digital.constellation_bpsk().base()</value>
+    </param>
+    <param>
+      <key>ted_type</key>
+      <value>digital.TED_SIGNUM_TIMES_SLOPE_ML</value>
     </param>
   </block>
   <block>
@@ -636,7 +887,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 908)</value>
+      <value>(184, 1116)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -687,7 +938,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(840, 528)</value>
+      <value>(1304, 704)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -749,7 +1000,7 @@
     </param>
     <param>
       <key>cutoff_freq</key>
-      <value>lpf_cutoff</value>
+      <value>baud_rate*.55</value>
     </param>
     <param>
       <key>decim</key>
@@ -765,7 +1016,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(248, 340)</value>
+      <value>(264, 372)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -797,7 +1048,7 @@
     </param>
     <param>
       <key>width</key>
-      <value>lpf_cutoff/2</value>
+      <value>baud_rate*.55/2</value>
     </param>
     <param>
       <key>win</key>
@@ -851,7 +1102,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 748)</value>
+      <value>(8, 956)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -898,7 +1149,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(376, 668)</value>
+      <value>(376, 876)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -945,7 +1196,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 668)</value>
+      <value>(184, 876)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -992,7 +1243,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 828)</value>
+      <value>(8, 1036)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1039,7 +1290,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 748)</value>
+      <value>(184, 956)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1086,7 +1337,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 908)</value>
+      <value>(8, 1116)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1118,65 +1369,6 @@
     </param>
   </block>
   <block>
-    <key>rational_resampler_xxx</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decim</key>
-      <value>target_samp_rate</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>fbw</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(840, 364)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>rational_resampler_xxx_0</value>
-    </param>
-    <param>
-      <key>interp</key>
-      <value>baud_rate*4</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>taps</key>
-      <value></value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>fff</value>
-    </param>
-  </block>
-  <block>
     <key>starcoder_ax25_decoder_bm</key>
     <param>
       <key>alias</key>
@@ -1200,7 +1392,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(592, 500)</value>
+      <value>(1056, 676)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1424,7 +1616,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 828)</value>
+      <value>(184, 1036)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1471,7 +1663,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 588)</value>
+      <value>(8, 796)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1509,8 +1701,32 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>blocks_add_const_vxx_0</source_block_id>
+    <sink_block_id>blocks_divide_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_divide_xx_0</source_block_id>
+    <sink_block_id>digital_symbol_sync_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_file_source_0</source_block_id>
     <sink_block_id>blocks_throttle_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_multiply_const_vxx_0</source_block_id>
+    <sink_block_id>blocks_add_const_vxx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_rms_xx_1</source_block_id>
+    <sink_block_id>blocks_multiply_const_vxx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -1534,7 +1750,13 @@
   </connection>
   <connection>
     <source_block_id>dc_blocker_xx_0</source_block_id>
-    <sink_block_id>rational_resampler_xxx_0</sink_block_id>
+    <sink_block_id>blocks_divide_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>dc_blocker_xx_0</source_block_id>
+    <sink_block_id>blocks_rms_xx_1</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -1545,7 +1767,7 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>digital_clock_recovery_mm_xx_0</source_block_id>
+    <source_block_id>digital_symbol_sync_xx_0</source_block_id>
     <sink_block_id>digital_binary_slicer_fb_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
@@ -1559,12 +1781,6 @@
   <connection>
     <source_block_id>low_pass_filter_0</source_block_id>
     <sink_block_id>analog_quadrature_demod_cf_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>rational_resampler_xxx_0</source_block_id>
-    <sink_block_id>digital_clock_recovery_mm_xx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>

--- a/flowgraphs/fsk_9600_ax25_transceiver.grc
+++ b/flowgraphs/fsk_9600_ax25_transceiver.grc
@@ -101,7 +101,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(208, 236)</value>
+      <value>(208, 172)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -114,33 +114,6 @@
     <param>
       <key>value</key>
       <value>9600</value>
-    </param>
-  </block>
-  <block>
-    <key>variable</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(208, 172)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>fsk_deviation_hz</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>10e3</value>
     </param>
   </block>
   <block>
@@ -168,6 +141,60 @@
     <param>
       <key>value</key>
       <value>8000</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(216, 604)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>nfilts</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>16</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(288, 604)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>rrc_taps</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>firdes.root_raised_cosine(nfilts, nfilts*sps_rx, 1, 0.35, 11*sps_rx*nfilts)</value>
     </param>
   </block>
   <block>
@@ -236,7 +263,61 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(208, 300)</value>
+      <value>(216, 668)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>sps_float</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>float(samp_rate)/baud_rate</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(312, 668)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>sps_rx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>int(round(float(samp_rate)/baud_rate))</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(208, 236)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -271,7 +352,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(800, 508)</value>
+      <value>(816, 436)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -279,7 +360,7 @@
     </param>
     <param>
       <key>gain</key>
-      <value>samp_rate/(20*math.pi*fsk_deviation_hz/8.0)</value>
+      <value>samp_rate/(20*math.pi*baud_rate/8.0)</value>
     </param>
     <param>
       <key>id</key>
@@ -397,6 +478,108 @@
     </param>
   </block>
   <block>
+    <key>blocks_add_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1e-20</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1448, 468)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_add_const_vxx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_divide_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1632, 440)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_divide_xx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
     <key>blocks_message_debug</key>
     <param>
       <key>alias</key>
@@ -416,7 +599,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1272, 664)</value>
+      <value>(1616, 648)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -511,6 +694,57 @@
     <param>
       <key>type</key>
       <value>complex</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_multiply_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1.0/1</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1296, 468)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_multiply_const_vxx_0_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
     </param>
     <param>
       <key>maxoutbuf</key>
@@ -703,6 +937,53 @@
     <param>
       <key>tag</key>
       <value>packet_len</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_rms_xx</key>
+    <param>
+      <key>alpha</key>
+      <value>.01</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1176, 468)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_rms_xx_1</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
     </param>
     <param>
       <key>maxoutbuf</key>
@@ -953,7 +1234,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(976, 500)</value>
+      <value>(1008, 428)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1145,7 +1426,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(640, 680)</value>
+      <value>(1016, 664)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1162,69 +1443,6 @@
     <param>
       <key>minoutbuf</key>
       <value>0</value>
-    </param>
-  </block>
-  <block>
-    <key>digital_clock_recovery_mm_xx</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(1312, 476)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>gain_mu</key>
-      <value>0.175</value>
-    </param>
-    <param>
-      <key>gain_omega</key>
-      <value>0.25*0.175*0.175</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>digital_clock_recovery_mm_xx_0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>mu</key>
-      <value>0.5</value>
-    </param>
-    <param>
-      <key>omega_relative_limit</key>
-      <value>0.005</value>
-    </param>
-    <param>
-      <key>omega</key>
-      <value>4</value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>float</value>
     </param>
   </block>
   <block>
@@ -1331,6 +1549,93 @@
     <param>
       <key>seed</key>
       <value>0x0</value>
+    </param>
+  </block>
+  <block>
+    <key>digital_symbol_sync_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>damping</key>
+      <value>.2</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>ted_gain</key>
+      <value>0.09501613+1.32802387/(1+(sps_float/28.7271)**2.541608)</value>
+    </param>
+    <param>
+      <key>nfilters</key>
+      <value>nfilts</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(600, 588)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>ff</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>digital_symbol_sync_xx_0</value>
+    </param>
+    <param>
+      <key>resamp_type</key>
+      <value>digital.IR_PFB_MF</value>
+    </param>
+    <param>
+      <key>loop_bw</key>
+      <value>3.1416/10</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>max_dev</key>
+      <value>0.01</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>osps</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>pfb_mf_taps</key>
+      <value>rrc_taps</value>
+    </param>
+    <param>
+      <key>sps</key>
+      <value>sps_float</value>
+    </param>
+    <param>
+      <key>constellation</key>
+      <value>digital.constellation_bpsk().base()</value>
+    </param>
+    <param>
+      <key>ted_type</key>
+      <value>digital.TED_SIGNUM_TIMES_SLOPE_ML</value>
     </param>
   </block>
   <block>
@@ -1478,7 +1783,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1016, 664)</value>
+      <value>(1432, 688)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1540,7 +1845,7 @@
     </param>
     <param>
       <key>cutoff_freq</key>
-      <value>lpf_cutoff</value>
+      <value>baud_rate*.55</value>
     </param>
     <param>
       <key>decim</key>
@@ -1556,7 +1861,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(608, 460)</value>
+      <value>(600, 388)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1588,7 +1893,7 @@
     </param>
     <param>
       <key>width</key>
-      <value>lpf_cutoff/2</value>
+      <value>baud_rate*.55/2</value>
     </param>
     <param>
       <key>win</key>
@@ -1624,65 +1929,6 @@
     <param>
       <key>id</key>
       <value>partial_iq_sink</value>
-    </param>
-  </block>
-  <block>
-    <key>rational_resampler_xxx</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decim</key>
-      <value>samp_rate</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>fbw</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(1136, 484)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>rational_resampler_xxx_0</value>
-    </param>
-    <param>
-      <key>interp</key>
-      <value>baud_rate*4</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>taps</key>
-      <value></value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>fff</value>
     </param>
   </block>
   <block>
@@ -2019,7 +2265,7 @@
     </param>
     <param>
       <key>postamble_bytes</key>
-      <value>1</value>
+      <value>4</value>
     </param>
     <param>
       <key>preamble_bytes</key>
@@ -2183,7 +2429,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(784, 636)</value>
+      <value>(1168, 620)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -3507,6 +3753,18 @@
     <sink_key>in</sink_key>
   </connection>
   <connection>
+    <source_block_id>blocks_add_const_vxx_0</source_block_id>
+    <sink_block_id>blocks_divide_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_divide_xx_0</source_block_id>
+    <sink_block_id>digital_symbol_sync_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_message_strobe_0</source_block_id>
     <sink_block_id>starcoder_pmt_to_pdu_0</sink_block_id>
     <source_key>strobe</source_key>
@@ -3515,6 +3773,12 @@
   <connection>
     <source_block_id>blocks_multiply_const_vxx_0</source_block_id>
     <sink_block_id>rational_resampler_xxx_0_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_multiply_const_vxx_0_0</source_block_id>
+    <sink_block_id>blocks_add_const_vxx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -3539,6 +3803,12 @@
   <connection>
     <source_block_id>blocks_pdu_to_tagged_stream_0_0</source_block_id>
     <sink_block_id>digital_scrambler_bb_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_rms_xx_1</source_block_id>
+    <sink_block_id>blocks_multiply_const_vxx_0_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -3568,19 +3838,19 @@
   </connection>
   <connection>
     <source_block_id>dc_blocker_xx_0</source_block_id>
-    <sink_block_id>rational_resampler_xxx_0</sink_block_id>
+    <sink_block_id>blocks_divide_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>dc_blocker_xx_0</source_block_id>
+    <sink_block_id>blocks_rms_xx_1</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
     <source_block_id>digital_binary_slicer_fb_0</source_block_id>
     <sink_block_id>starcoder_ax25_decoder_bm_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>digital_clock_recovery_mm_xx_0</source_block_id>
-    <sink_block_id>digital_binary_slicer_fb_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -3593,6 +3863,12 @@
   <connection>
     <source_block_id>digital_scrambler_bb_0</source_block_id>
     <sink_block_id>satellites_nrzi_encode_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>digital_symbol_sync_xx_0</source_block_id>
+    <sink_block_id>digital_binary_slicer_fb_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -3611,12 +3887,6 @@
   <connection>
     <source_block_id>low_pass_filter_0</source_block_id>
     <sink_block_id>analog_quadrature_demod_cf_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>rational_resampler_xxx_0</source_block_id>
-    <sink_block_id>digital_clock_recovery_mm_xx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>

--- a/flowgraphs/fsk_ax100.grc
+++ b/flowgraphs/fsk_ax100.grc
@@ -101,7 +101,34 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 332)</value>
+      <value>(8, 460)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>180</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>nfilts</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>16</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(80, 460)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -109,11 +136,11 @@
     </param>
     <param>
       <key>id</key>
-      <value>fsk_deviation_hz</value>
+      <value>rrc_taps</value>
     </param>
     <param>
       <key>value</key>
-      <value>10e3</value>
+      <value>firdes.root_raised_cosine(nfilts, nfilts*sps_rx, 1, 0.35, 11*sps_rx*nfilts)</value>
     </param>
   </block>
   <block>
@@ -144,6 +171,60 @@
     </param>
   </block>
   <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(8, 524)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>sps_float</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>float(target_samp_rate)/baud_rate</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(104, 524)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>sps_rx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>int(round(float(target_samp_rate)/baud_rate))</value>
+    </param>
+  </block>
+  <block>
     <key>analog_quadrature_demod_cf</key>
     <param>
       <key>alias</key>
@@ -171,7 +252,7 @@
     </param>
     <param>
       <key>gain</key>
-      <value>target_samp_rate/(20*math.pi*fsk_deviation_hz/8.0)</value>
+      <value>target_samp_rate/(20*math.pi*baud_rate/8.0)</value>
     </param>
     <param>
       <key>id</key>
@@ -202,7 +283,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(376, 884)</value>
+      <value>(376, 980)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -231,6 +312,108 @@
     <param>
       <key>value</key>
       <value>4800</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_add_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1e-20</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1152, 420)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_add_const_vxx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_divide_xx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1320, 392)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_divide_xx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>num_inputs</key>
+      <value>2</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
     </param>
   </block>
   <block>
@@ -308,11 +491,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>0</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1120, 672)</value>
+      <value>(1336, 744)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -321,6 +504,57 @@
     <param>
       <key>id</key>
       <value>blocks_message_debug_0</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_multiply_const_vxx</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>const</key>
+      <value>1.0/1</value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(984, 420)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_multiply_const_vxx_0</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>vlen</key>
+      <value>1</value>
     </param>
   </block>
   <block>
@@ -347,7 +581,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(480, 676)</value>
+      <value>(696, 748)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -372,6 +606,53 @@
     <param>
       <key>vlen</key>
       <value>1</value>
+    </param>
+  </block>
+  <block>
+    <key>blocks_rms_xx</key>
+    <param>
+      <key>alpha</key>
+      <value>.01</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(856, 420)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>blocks_rms_xx_1</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
     </param>
   </block>
   <block>
@@ -445,7 +726,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(376, 1044)</value>
+      <value>(376, 1140)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -492,7 +773,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(552, 884)</value>
+      <value>(552, 980)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -543,7 +824,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(672, 380)</value>
+      <value>(648, 380)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -590,7 +871,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 804)</value>
+      <value>(8, 900)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -641,7 +922,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(656, 544)</value>
+      <value>(872, 616)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -680,7 +961,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(656, 680)</value>
+      <value>(872, 752)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -700,7 +981,7 @@
     </param>
   </block>
   <block>
-    <key>digital_clock_recovery_mm_xx</key>
+    <key>digital_symbol_sync_xx</key>
     <param>
       <key>alias</key>
       <value></value>
@@ -714,52 +995,76 @@
       <value></value>
     </param>
     <param>
+      <key>damping</key>
+      <value>.2</value>
+    </param>
+    <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>True</value>
+    </param>
+    <param>
+      <key>ted_gain</key>
+      <value>0.09501613+1.32802387/(1+(sps_float/28.7271)**2.541608)</value>
+    </param>
+    <param>
+      <key>nfilters</key>
+      <value>nfilts</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(248, 508)</value>
+      <value>(296, 588)</value>
     </param>
     <param>
       <key>_rotation</key>
       <value>0</value>
     </param>
     <param>
-      <key>gain_mu</key>
-      <value>0.175</value>
-    </param>
-    <param>
-      <key>gain_omega</key>
-      <value>0.25*0.175*0.175</value>
+      <key>type</key>
+      <value>ff</value>
     </param>
     <param>
       <key>id</key>
-      <value>digital_clock_recovery_mm_xx_0</value>
+      <value>digital_symbol_sync_xx_0</value>
+    </param>
+    <param>
+      <key>resamp_type</key>
+      <value>digital.IR_PFB_MF</value>
+    </param>
+    <param>
+      <key>loop_bw</key>
+      <value>3.1416/10</value>
     </param>
     <param>
       <key>maxoutbuf</key>
       <value>0</value>
     </param>
     <param>
+      <key>max_dev</key>
+      <value>0.01</value>
+    </param>
+    <param>
       <key>minoutbuf</key>
       <value>0</value>
     </param>
     <param>
-      <key>mu</key>
-      <value>0.5</value>
+      <key>osps</key>
+      <value>1</value>
     </param>
     <param>
-      <key>omega_relative_limit</key>
-      <value>0.005</value>
+      <key>pfb_mf_taps</key>
+      <value>rrc_taps</value>
     </param>
     <param>
-      <key>omega</key>
-      <value>4</value>
+      <key>sps</key>
+      <value>sps_float</value>
     </param>
     <param>
-      <key>type</key>
-      <value>float</value>
+      <key>constellation</key>
+      <value>digital.constellation_bpsk().base()</value>
+    </param>
+    <param>
+      <key>ted_type</key>
+      <value>digital.TED_SIGNUM_TIMES_SLOPE_ML</value>
     </param>
   </block>
   <block>
@@ -817,7 +1122,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 1044)</value>
+      <value>(184, 1140)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -868,7 +1173,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(1120, 616)</value>
+      <value>(1336, 688)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -930,7 +1235,7 @@
     </param>
     <param>
       <key>cutoff_freq</key>
-      <value>int(0.83*baud_rate)</value>
+      <value>baud_rate*.55</value>
     </param>
     <param>
       <key>decim</key>
@@ -978,7 +1283,7 @@
     </param>
     <param>
       <key>width</key>
-      <value>int(0.83*baud_rate/2)</value>
+      <value>baud_rate*.55/2</value>
     </param>
     <param>
       <key>win</key>
@@ -1032,7 +1337,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 884)</value>
+      <value>(8, 980)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1079,7 +1384,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(376, 804)</value>
+      <value>(376, 900)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1126,7 +1431,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 804)</value>
+      <value>(184, 900)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1173,7 +1478,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 964)</value>
+      <value>(8, 1060)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1220,7 +1525,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 884)</value>
+      <value>(184, 980)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1267,7 +1572,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 1044)</value>
+      <value>(8, 1140)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1299,65 +1604,6 @@
     </param>
   </block>
   <block>
-    <key>rational_resampler_xxx</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>decim</key>
-      <value>target_samp_rate</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>fbw</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(840, 364)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>rational_resampler_xxx_0</value>
-    </param>
-    <param>
-      <key>interp</key>
-      <value>baud_rate*4</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>taps</key>
-      <value></value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>fff</value>
-    </param>
-  </block>
-  <block>
     <key>parameter</key>
     <param>
       <key>alias</key>
@@ -1373,7 +1619,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(552, 804)</value>
+      <value>(552, 900)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1448,7 +1694,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(824, 500)</value>
+      <value>(1040, 572)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1511,7 +1757,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(824, 636)</value>
+      <value>(1040, 708)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1715,7 +1961,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(376, 964)</value>
+      <value>(376, 1060)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1762,7 +2008,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(184, 964)</value>
+      <value>(184, 1060)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1809,7 +2055,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(8, 724)</value>
+      <value>(8, 820)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1847,14 +2093,38 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>blocks_add_const_vxx_0</source_block_id>
+    <sink_block_id>blocks_divide_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>1</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_divide_xx_0</source_block_id>
+    <sink_block_id>digital_symbol_sync_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_file_source_0</source_block_id>
     <sink_block_id>blocks_throttle_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>blocks_multiply_const_vxx_0</source_block_id>
+    <sink_block_id>blocks_add_const_vxx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_multiply_const_vxx_0_0</source_block_id>
     <sink_block_id>digital_binary_slicer_fb_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>blocks_rms_xx_1</source_block_id>
+    <sink_block_id>blocks_multiply_const_vxx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -1878,7 +2148,13 @@
   </connection>
   <connection>
     <source_block_id>dc_blocker_xx_0</source_block_id>
-    <sink_block_id>rational_resampler_xxx_0</sink_block_id>
+    <sink_block_id>blocks_divide_xx_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>dc_blocker_xx_0</source_block_id>
+    <sink_block_id>blocks_rms_xx_1</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -1895,13 +2171,13 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>digital_clock_recovery_mm_xx_0</source_block_id>
+    <source_block_id>digital_symbol_sync_xx_0</source_block_id>
     <sink_block_id>blocks_multiply_const_vxx_0_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
-    <source_block_id>digital_clock_recovery_mm_xx_0</source_block_id>
+    <source_block_id>digital_symbol_sync_xx_0</source_block_id>
     <sink_block_id>digital_binary_slicer_fb_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
@@ -1915,12 +2191,6 @@
   <connection>
     <source_block_id>low_pass_filter_0</source_block_id>
     <sink_block_id>analog_quadrature_demod_cf_0</sink_block_id>
-    <source_key>0</source_key>
-    <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>rational_resampler_xxx_0</source_block_id>
-    <sink_block_id>digital_clock_recovery_mm_xx_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>


### PR DESCRIPTION
FSK demodulator upgraded with newer Symbol Sync module and improved Low pass filter parameters.

Configured parameters tested for optimum GFSK 9600bps performance. Capable (but still not implemented) of different bitrate as well. Tests with AISTECH passes shows +40% performance in successful received packets.

Other changes: AX25 transmitted postamble = 4 on fsk_ax25_9600_transceiver.

There are 3 modified flowgraphs:
-fsk_9600:
![fsk_9600](https://user-images.githubusercontent.com/39289576/54106908-f9a9bd00-441a-11e9-9ddd-9cab8661fe65.png)
-fsk_9600_ax25_transceiver:
![fsk_9600_ax25_transceiver](https://user-images.githubusercontent.com/39289576/54106946-1940e580-441b-11e9-8d99-3a1e436b2deb.png)
-fsk_ax100:
![fsk_ax100](https://user-images.githubusercontent.com/39289576/54106979-32e22d00-441b-11e9-9cb6-5a251d3e0afa.png)
