### PR TITLE
Graceful shutdown with SIGHUP

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -167,9 +167,9 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func doRestart(starcoder *server.StarCoder, s *grpc.Server) {
+func doRestart(starcoder *server.Starcoder, s *grpc.Server) {
 	for {
-		if starcoder.getCurrentFlowgraphCount() == 0 {
+		if starcoder.GetCurrentFlowgraphCount() == 0 {
 			starcoder.Close()
 			s.GracefulStop()
 			return

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -140,6 +140,9 @@ var serveCmd = &cobra.Command{
 				select {
 				case sig := <-sigs:
 					switch sig {
+					case syscall.SIGHUP:
+						log.Infof("Starcoder will restart.")
+						go doRestart(starcoder, s)
 					case syscall.SIGINT:
 						fallthrough
 					case syscall.SIGTERM:
@@ -162,6 +165,17 @@ var serveCmd = &cobra.Command{
 			log.Fatalf("failed to serve: %v", err)
 		}
 	},
+}
+
+func doRestart(starcoder *server.StarCoder, s *grpc.Server) {
+	for {
+		if starcoder.getCurrentFlowgraphCount() == 0 {
+			starcoder.Close()
+			s.GracefulStop()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func init() {

--- a/server/starcoder.go
+++ b/server/starcoder.go
@@ -149,15 +149,15 @@ func NewStarcoderServer(flowgraphDir string, perfCtrInterval time.Duration, sile
 	return s
 }
 
+func (s *Starcoder) GetCurrentFlowgraphCount() int {
+	s.requestFlowgraphCountChannel <- struct{}{}
+	return <-s.responseFlowgraphCountChannel
+}
+
 func (s *Starcoder) closeAllStreams() {
 	respCh := make(chan bool)
 	s.closeAllStreamsChannel <- respCh
 	<-respCh
-}
-
-func (s *Starcoder) getCurrentFlowgraphCount() int {
-	s.requestFlowgraphCountChannel <- struct{}{}
-	return <-s.responseFlowgraphCountChannel
 }
 
 type flowgraphProperties struct {


### PR DESCRIPTION
Currently Starcoder will exit immediately if it get signals.
This change enables that Starcoder wait for finishing flow graph execution before exiting if it get SIGHUP.