### PR TITLE
Compile gr-satellites hierarchical blocks 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -380,8 +380,16 @@ task installStarcoder(type: Copy) {
     into "${gnuradioRoot}/bin"
 }
 
+task compileGrSatellitesHierarchicalBlocks(type: org.curioswitch.gradle.conda.tasks.CondaExecTask) {
+    dependsOn setupPrefix
+
+    condaName 'gnuradio'
+
+    command "git clone https://github.com/daniestevez/gr-satellites.git /tmp/gr-satellites && cd /tmp/gr-satellites/ && ./compile_hierarchical.sh"
+}
+
 task install {
-    dependsOn installGrStarcoder, installGrStarcoderUtils, installStarcoder
+    dependsOn compileGrSatellitesHierarchicalBlocks, installGrStarcoder, installGrStarcoderUtils, installStarcoder
 }
 
 task clangFormat(type: org.curioswitch.gradle.conda.tasks.CondaExecTask) {

--- a/tools/builder/Dockerfile
+++ b/tools/builder/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/share/gnuradio /root/.gra
 COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/share/uhd /root/.gradle/curiostack/gnuradio/4.4.10/share/uhd
 COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/ssl /root/.gradle/curiostack/gnuradio/4.4.10/ssl
 COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/x86_64-conda_cos6-linux-gnu /root/.gradle/curiostack/gnuradio/4.4.10/x86_64-conda_cos6-linux-gnu
+COPY --from=0 /root/.grc_gnuradio /root/.grc_gnuradio
 
 
 COPY --from=0 /root/.gradle/curiostack/gnuradio/4.4.10/bin/conda \


### PR DESCRIPTION
Compile gr-satellites hierarchical blocks so we can use them as-is in flowgraphs.