### PR TITLE
fix bugs in start_flowgraph.py

### DIFF
--- a/gr-starcoder/apps/scripts/start_flowgraph.py
+++ b/gr-starcoder/apps/scripts/start_flowgraph.py
@@ -36,8 +36,7 @@ import sys
 import subprocess
 import importlib
 import tempfile
-import yaml
-_mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
+import ruamel.yaml as yaml
 from itertools import izip
 import time
 
@@ -143,11 +142,11 @@ if __name__ == "__main__":
     print("Using flowgraph file: {}".format(args.flowgraph))
     print("Using flowgraph configuration file: {}".format(args.flowgraph_config))
     print("Files to collect: {}".format(args.collect))
-    if len(args.collect) % 2 != 0:
+    if args.collect and len(args.collect) % 2 != 0:
         raise Exception('files_to_collect does not have an even number of elements. Do all files have a frame type?')
     print("Reading flowgraph configuration..")
     with open(args.flowgraph_config) as f:
-        flowgraph_config = yaml.load(f, Loader=yaml.FullLoader)
+        flowgraph_config = yaml.load(f)
         if flowgraph_config is None:
             flowgraph_config = dict()
     print('Flowgraph configuration', json.dumps(flowgraph_config, indent=2))


### PR DESCRIPTION
We're replacing PyYaml with ruamel.yaml which is a maintained fork of PyYaml. https://yaml.readthedocs.io/en/latest/pyyaml.html

We ran into this bug https://stackoverflow.com/questions/30458977/yaml-loads-5e-6-as-string-and-not-a-number